### PR TITLE
fix: 文档预览时主 chat 滚动条穿透

### DIFF
--- a/src/renderer/components/FilePreviewModal.tsx
+++ b/src/renderer/components/FilePreviewModal.tsx
@@ -10,6 +10,7 @@
  */
 import { Edit2, FileText, FolderOpen, Loader2, Save, X } from 'lucide-react';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
@@ -296,11 +297,13 @@ export default function FilePreviewModal({
         );
     };
 
-    return (
+    // Render via portal to document.body to avoid chat scrollbar penetrating through
+    // (parent stacking context from Chat/DirectoryPanel would otherwise overlay scrollbar on modal)
+    return createPortal(
         <>
             {/* Modal backdrop */}
             <div
-                className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm"
+                className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
                 style={{ padding: '2vh 2vw' }}
                 onMouseDown={handleBackdropMouseDown}
                 onClick={handleBackdropClick}
@@ -412,6 +415,7 @@ export default function FilePreviewModal({
                     onCancel={() => setShowUnsavedConfirm(false)}
                 />
             )}
-        </>
+        </>,
+        document.body
     );
 }


### PR DESCRIPTION
- 使用 createPortal 将 FilePreviewModal 渲染到 document.body
- 避免父级 stacking context 导致 chat 滚动条叠在文档上方
- z-index 提升至 z-50 与 UnifiedLogsPanel 一致

Made-with: Cursor

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's code style
- [ ] I have run `npm run typecheck` and `npm run lint`
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed

## Related Issues

Fixes #(issue number)

## Screenshots (if applicable)
### Before
<img width="2400" height="1596" alt="aaaa" src="https://github.com/user-attachments/assets/880e08d5-2a9f-48c2-a8ff-3d1f63e15f69" />


### After
<img width="2400" height="1596" alt="bbbb" src="https://github.com/user-attachments/assets/ef76176b-95ae-4040-b97b-bcb4f382369a" />


Add screenshots to demonstrate the changes.
