### PR TITLE
fix: guard mkdirSync against EEXIST on Bun/Windows

### DIFF
--- a/src/server/agent-session.ts
+++ b/src/server/agent-session.ts
@@ -161,7 +161,7 @@ export function syncProjectUserConfig(projectDir: string): void {
   const projectSkillsDir = join(projectDir, '.claude', 'skills');
 
   if (existsSync(userSkillsDir)) {
-    mkdirSync(projectSkillsDir, { recursive: true });
+    try { mkdirSync(projectSkillsDir, { recursive: true }); } catch (e: any) { if (e?.code !== 'EEXIST') throw e; }
 
     // Read disabled list from skills-config.json
     let disabled: string[] = [];
@@ -235,7 +235,7 @@ export function syncProjectUserConfig(projectDir: string): void {
   const projectCommandsDir = join(projectDir, '.claude', 'commands');
 
   if (existsSync(userCommandsDir)) {
-    mkdirSync(projectCommandsDir, { recursive: true });
+    try { mkdirSync(projectCommandsDir, { recursive: true }); } catch (e: any) { if (e?.code !== 'EEXIST') throw e; }
 
     // Track managed command filenames for dangling symlink cleanup
     const managedCommandFiles = new Set<string>();


### PR DESCRIPTION
## Summary

- `syncProjectUserConfig()` in `agent-session.ts` calls `mkdirSync({ recursive: true })` for `.claude/skills` and `.claude/commands` directories
- **Bun on Windows** throws `EEXIST` when the directory already exists, unlike Node.js which silently succeeds
- This crashes **all Agent Channel sessions** (Telegram bots, etc.) on every incoming message — bots silently stop responding

## Fix

Wrap both `mkdirSync` calls in try-catch that ignores `EEXIST` while still propagating other errors. Two-line change.

## Error log

```
[BUN] [ERROR] [agent] failed to start session Error: EEXIST: file already exists,
  mkdir '...\.claude\skills'
    at syncProjectUserConfig (server-dist.js:145109:16)
    at startStreamingSession (server-dist.js:148031:24)
```

## Test plan

- [ ] On Windows with Bun runtime, create an Agent with a Telegram Channel
- [ ] Ensure workspace has existing `.claude/skills/` and `.claude/commands/` directories
- [ ] Send a message to the bot — should respond instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)