### PR TITLE
feat(provider): add enablement and ordering

### DIFF
--- a/src/renderer/components/ProviderEnableOrderDialog.tsx
+++ b/src/renderer/components/ProviderEnableOrderDialog.tsx
@@ -1,0 +1,276 @@
+import React, { useCallback, useMemo } from 'react';
+import { ArrowDown, ArrowUp, GripVertical, X } from 'lucide-react';
+import {
+    closestCenter,
+    DndContext,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+    arrayMove,
+    SortableContext,
+    sortableKeyboardCoordinates,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+import OverlayBackdrop from '@/components/OverlayBackdrop';
+import { normalizeProviderOrder, type Provider } from '@/config/types';
+
+interface ProviderEnableOrderDialogProps {
+    providers: Provider[];
+    providerOrderDraft: string[];
+    disabledProviderDraft: string[];
+    onProviderOrderDraftChange: React.Dispatch<React.SetStateAction<string[]>>;
+    onDisabledProviderDraftChange: React.Dispatch<React.SetStateAction<string[]>>;
+    onClose: () => void;
+    onSave: () => void;
+}
+
+interface ProviderOrderRowProps {
+    provider: Provider;
+    index: number;
+    isLast: boolean;
+    enabled: boolean;
+    onMove: (providerId: string, direction: -1 | 1) => void;
+    onToggle: (providerId: string, enabled: boolean) => void;
+}
+
+function ProviderOrderRow({ provider, index, isLast, enabled, onMove, onToggle }: ProviderOrderRowProps) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: provider.id });
+
+    const style: React.CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            className={`flex items-center gap-3 rounded-xl border border-[var(--line)] bg-[var(--paper)] px-3 py-3 transition-shadow ${isDragging ? 'relative z-10 shadow-lg ring-1 ring-[var(--focus-border)]' : ''} ${enabled ? '' : 'opacity-60'}`}
+        >
+            <button
+                type="button"
+                {...attributes}
+                {...listeners}
+                className="rounded-md p-1.5 text-[var(--ink-muted)] transition-colors hover:bg-[var(--paper-inset)] hover:text-[var(--ink)] active:cursor-grabbing"
+                title="拖拽排序"
+                aria-label={`拖拽排序 ${provider.name}`}
+            >
+                <GripVertical className="h-4 w-4" />
+            </button>
+            <div className="flex w-16 shrink-0 items-center gap-1">
+                <button
+                    type="button"
+                    onClick={() => onMove(provider.id, -1)}
+                    disabled={index === 0}
+                    className="rounded-md p-1.5 text-[var(--ink-muted)] transition-colors hover:bg-[var(--paper-inset)] hover:text-[var(--ink)] disabled:opacity-35"
+                    title="上移"
+                >
+                    <ArrowUp className="h-3.5 w-3.5" />
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onMove(provider.id, 1)}
+                    disabled={isLast}
+                    className="rounded-md p-1.5 text-[var(--ink-muted)] transition-colors hover:bg-[var(--paper-inset)] hover:text-[var(--ink)] disabled:opacity-35"
+                    title="下移"
+                >
+                    <ArrowDown className="h-3.5 w-3.5" />
+                </button>
+            </div>
+            <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 items-center gap-2">
+                    <p className="truncate text-sm font-medium text-[var(--ink)]">{provider.name}</p>
+                    <span className="shrink-0 rounded bg-[var(--paper-inset)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--ink-muted)]">
+                        {provider.cloudProvider}
+                    </span>
+                    <span className="shrink-0 rounded bg-[var(--paper-inset)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--ink-muted)]">
+                        {provider.type === 'subscription' ? '订阅' : 'API'}
+                    </span>
+                </div>
+                <p className="mt-0.5 truncate text-xs text-[var(--ink-muted)]">
+                    {provider.models.length > 0
+                        ? provider.models.map(model => model.modelName || model.model).join(', ')
+                        : '暂无模型'}
+                </p>
+            </div>
+            <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                onClick={() => onToggle(provider.id, !enabled)}
+                className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent transition-colors ${enabled ? 'bg-[var(--accent)]' : 'bg-[var(--line-strong)]'}`}
+                title={enabled ? '已启用' : '已禁用'}
+            >
+                <span className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-[var(--toggle-thumb)] shadow-sm transition-transform ${enabled ? 'translate-x-5' : 'translate-x-0.5'}`} />
+            </button>
+        </div>
+    );
+}
+
+export default function ProviderEnableOrderDialog({
+    providers,
+    providerOrderDraft,
+    disabledProviderDraft,
+    onProviderOrderDraftChange,
+    onDisabledProviderDraftChange,
+    onClose,
+    onSave,
+}: ProviderEnableOrderDialogProps) {
+    const providerRows = useMemo(() => {
+        const byId = new Map(providers.map(provider => [provider.id, provider] as const));
+        return normalizeProviderOrder(providers.map(provider => provider.id), providerOrderDraft)
+            .map(id => byId.get(id))
+            .filter((provider): provider is Provider => Boolean(provider));
+    }, [providers, providerOrderDraft]);
+
+    const disabledSet = useMemo(
+        () => new Set(disabledProviderDraft),
+        [disabledProviderDraft],
+    );
+    const enabledCount = providerRows.length - disabledSet.size;
+    const allEnabled = providerRows.length > 0 && disabledSet.size === 0;
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: { distance: 6 },
+        }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        }),
+    );
+
+    const moveProvider = useCallback((providerId: string, direction: -1 | 1) => {
+        onProviderOrderDraftChange((current) => {
+            const normalized = normalizeProviderOrder(providers.map(provider => provider.id), current);
+            const index = normalized.indexOf(providerId);
+            const nextIndex = index + direction;
+            if (index < 0 || nextIndex < 0 || nextIndex >= normalized.length) return normalized;
+            const next = [...normalized];
+            [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+            return next;
+        });
+    }, [providers, onProviderOrderDraftChange]);
+
+    const handleDragEnd = useCallback((event: DragEndEvent) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+
+        onProviderOrderDraftChange((current) => {
+            const normalized = normalizeProviderOrder(providers.map(provider => provider.id), current);
+            const oldIndex = normalized.indexOf(String(active.id));
+            const newIndex = normalized.indexOf(String(over.id));
+            if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return normalized;
+            return arrayMove(normalized, oldIndex, newIndex);
+        });
+    }, [providers, onProviderOrderDraftChange]);
+
+    const toggleProviderEnabled = useCallback((providerId: string, enabled: boolean) => {
+        onDisabledProviderDraftChange((current) => {
+            if (enabled) return current.filter(id => id !== providerId);
+            return current.includes(providerId) ? current : [...current, providerId];
+        });
+    }, [onDisabledProviderDraftChange]);
+
+    const toggleAllProvidersEnabled = useCallback(() => {
+        onDisabledProviderDraftChange(allEnabled
+            ? providers.map(provider => provider.id)
+            : []);
+    }, [providers, allEnabled, onDisabledProviderDraftChange]);
+
+    return (
+        <OverlayBackdrop className="z-50 overflow-y-auto py-8">
+            <div className="mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col rounded-2xl bg-[var(--paper-elevated)] shadow-xl">
+                <div className="flex-shrink-0 px-6 pb-4 pt-6">
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <h3 className="text-lg font-semibold text-[var(--ink)]">启用和排序</h3>
+                            <p className="mt-1 text-sm text-[var(--ink-muted)]">
+                                控制可被对话、任务和聊天机器人使用的供应商，以及它们在模型选择器中的顺序。
+                            </p>
+                        </div>
+                        <button
+                            onClick={onClose}
+                            className="rounded-lg p-1.5 text-[var(--ink-muted)] transition-colors hover:bg-[var(--paper-inset)]"
+                            aria-label="关闭"
+                        >
+                            <X className="h-5 w-5" />
+                        </button>
+                    </div>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4">
+                    <div className="mb-3 flex items-center justify-between rounded-xl border border-[var(--line)] bg-[var(--paper)] px-3 py-2">
+                        <div>
+                            <p className="text-sm font-medium text-[var(--ink)]">
+                                已启用 {Math.max(0, enabledCount)} / {providerRows.length}
+                            </p>
+                            <p className="text-xs text-[var(--ink-muted)]">
+                                禁用的供应商会从设置列表和模型选择器隐藏；重新启用会保留已有配置。
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={toggleAllProvidersEnabled}
+                            className="rounded-lg border border-[var(--line)] px-3 py-1.5 text-sm font-medium text-[var(--ink)] transition-colors hover:bg-[var(--paper-inset)]"
+                        >
+                            {allEnabled ? '取消全选' : '全选'}
+                        </button>
+                    </div>
+                    <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        onDragEnd={handleDragEnd}
+                    >
+                        <SortableContext
+                            items={providerRows.map(provider => provider.id)}
+                            strategy={verticalListSortingStrategy}
+                        >
+                            <div className="space-y-2">
+                                {providerRows.map((provider, index) => (
+                                    <ProviderOrderRow
+                                        key={provider.id}
+                                        provider={provider}
+                                        index={index}
+                                        isLast={index === providerRows.length - 1}
+                                        enabled={!disabledSet.has(provider.id)}
+                                        onMove={moveProvider}
+                                        onToggle={toggleProviderEnabled}
+                                    />
+                                ))}
+                            </div>
+                        </SortableContext>
+                    </DndContext>
+                </div>
+
+                <div className="flex flex-shrink-0 justify-end gap-3 border-t border-[var(--line)] px-6 py-4">
+                    <button
+                        onClick={onClose}
+                        className="rounded-lg border border-[var(--line)] px-4 py-2.5 text-sm font-medium text-[var(--ink)] transition-colors hover:bg-[var(--paper-inset)]"
+                    >
+                        取消
+                    </button>
+                    <button
+                        onClick={onSave}
+                        className="rounded-lg bg-[var(--button-primary-bg)] px-4 py-2.5 text-sm font-medium text-[var(--button-primary-text)] transition-colors hover:bg-[var(--button-primary-bg-hover)]"
+                    >
+                        保存
+                    </button>
+                </div>
+            </div>
+        </OverlayBackdrop>
+    );
+}

--- a/src/renderer/config/ConfigProvider.tsx
+++ b/src/renderer/config/ConfigProvider.tsx
@@ -11,6 +11,7 @@ import {
     type Provider,
     type ProviderVerifyStatus,
     PRESET_PROVIDERS,
+    applyProviderEnablementAndOrder,
 } from './types';
 import {
     loadAppConfig,
@@ -150,16 +151,30 @@ export function ConfigProvider({ children }: { children: React.ReactNode }) {
     // Derived: merge preset custom models + apply user primary model overrides
     const providers = useMemo(() => {
         const merged = mergePresetCustomModels(rawProviders, config.presetCustomModels, config.presetRemovedModels);
+        const providerOrderSettings = {
+            providerOrder: config.providerOrder,
+            disabledProviderIds: config.disabledProviderIds,
+        };
         const overrides = config.providerPrimaryModels;
-        if (!overrides || Object.keys(overrides).length === 0) return merged;
+        if (!overrides || Object.keys(overrides).length === 0) {
+            return applyProviderEnablementAndOrder(merged, providerOrderSettings);
+        }
         // Apply user's primaryModel override directly on the Provider object
         // so ALL consumers see the correct value without needing getEffectivePrimaryModel()
-        return merged.map(p => {
+        const withPrimaryOverrides = merged.map(p => {
             const userPrimary = overrides[p.id];
             if (!userPrimary || !p.models?.some(m => m.model === userPrimary)) return p;
             return { ...p, primaryModel: userPrimary };
         });
-    }, [rawProviders, config.presetCustomModels, config.presetRemovedModels, config.providerPrimaryModels]);
+        return applyProviderEnablementAndOrder(withPrimaryOverrides, providerOrderSettings);
+    }, [
+        rawProviders,
+        config.presetCustomModels,
+        config.presetRemovedModels,
+        config.providerPrimaryModels,
+        config.providerOrder,
+        config.disabledProviderIds,
+    ]);
 
     // Mount guard
     const isMountedRef = useRef(true);

--- a/src/renderer/config/providerEnablement.test.ts
+++ b/src/renderer/config/providerEnablement.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyProviderEnablementAndOrder,
+  isProviderEnabled,
+  normalizeDisabledProviderIds,
+  normalizeProviderOrder,
+  type Provider,
+} from './types';
+
+const makeProvider = (id: string): Provider => ({
+  id,
+  name: id,
+  vendor: 'Test',
+  cloudProvider: 'Test',
+  type: 'api',
+  primaryModel: `${id}-model`,
+  isBuiltin: false,
+  authType: 'api_key',
+  config: { baseUrl: `https://${id}.example/v1` },
+  models: [{ model: `${id}-model`, modelName: `${id} Model`, modelSeries: 'test' }],
+});
+
+describe('provider enablement and ordering helpers', () => {
+  it('normalizes order by removing unknowns and appending new providers', () => {
+    expect(normalizeProviderOrder(['alpha', 'beta', 'gamma'], [
+      'missing',
+      'gamma',
+      'alpha',
+      'gamma',
+    ])).toEqual(['gamma', 'alpha', 'beta']);
+  });
+
+  it('normalizes disabled ids by keeping only known unique providers', () => {
+    expect(normalizeDisabledProviderIds(['alpha', 'beta'], [
+      'missing',
+      'alpha',
+      'alpha',
+    ])).toEqual(['alpha']);
+  });
+
+  it('applies enabled flags and configured order without mutating defaults', () => {
+    const providers = ['alpha', 'beta', 'gamma'].map(makeProvider);
+    const ordered = applyProviderEnablementAndOrder(providers, {
+      providerOrder: ['gamma', 'alpha'],
+      disabledProviderIds: ['alpha'],
+    });
+
+    expect(ordered.map(provider => provider.id)).toEqual(['gamma', 'alpha', 'beta']);
+    expect(ordered.find(provider => provider.id === 'alpha')?.enabled).toBe(false);
+    expect(isProviderEnabled(ordered.find(provider => provider.id === 'gamma'))).toBe(true);
+    expect(providers.find(provider => provider.id === 'alpha')?.enabled).toBeUndefined();
+  });
+});

--- a/src/renderer/config/services/providerService.test.ts
+++ b/src/renderer/config/services/providerService.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_CONFIG,
+    applyProviderEnablementAndOrder,
+    type Provider,
+} from '../types';
+import {
+    getFirstAvailableProvider,
+    isProviderAvailable,
+    resolveBuiltinSelection,
+} from './providerService';
+
+const makeProvider = (id: string, primaryModel = `${id}-model`): Provider => ({
+    id,
+    name: id,
+    vendor: 'Test',
+    cloudProvider: 'Test',
+    type: 'api',
+    primaryModel,
+    isBuiltin: false,
+    authType: 'api_key',
+    config: { baseUrl: `https://${id}.example/v1` },
+    models: [{ model: primaryModel, modelName: `${id} Model`, modelSeries: 'test' }],
+});
+
+describe('provider availability with enablement', () => {
+    it('treats disabled providers as unavailable even when they have credentials', () => {
+        const providers = applyProviderEnablementAndOrder(
+            [makeProvider('alpha'), makeProvider('beta')],
+            { disabledProviderIds: ['alpha'] },
+        );
+        const alpha = providers.find(provider => provider.id === 'alpha');
+
+        expect(alpha).toBeDefined();
+        expect(isProviderAvailable(alpha!, { alpha: 'configured-key' }, {})).toBe(false);
+    });
+
+    it('first available provider follows user ordering and skips disabled providers', () => {
+        const providers = applyProviderEnablementAndOrder(
+            [makeProvider('alpha'), makeProvider('beta'), makeProvider('gamma')],
+            {
+                providerOrder: ['gamma', 'alpha', 'beta'],
+                disabledProviderIds: ['alpha'],
+            },
+        );
+
+        expect(getFirstAvailableProvider(providers, {
+            alpha: 'alpha-key',
+            beta: 'beta-key',
+            gamma: 'gamma-key',
+        }, {})?.id).toBe('gamma');
+    });
+
+    it('builtin selection falls through from a disabled default provider', () => {
+        const providers = applyProviderEnablementAndOrder(
+            [makeProvider('alpha'), makeProvider('beta', 'beta-primary')],
+            {
+                providerOrder: ['alpha', 'beta'],
+                disabledProviderIds: ['alpha'],
+            },
+        );
+        const selection = resolveBuiltinSelection(
+            {},
+            { ...DEFAULT_CONFIG, defaultProviderId: 'alpha' },
+            providers,
+            {
+                alpha: 'alpha-key',
+                beta: 'beta-key',
+            },
+            {},
+        );
+
+        expect(selection?.provider.id).toBe('beta');
+        expect(selection?.model).toBe('beta-primary');
+    });
+});

--- a/src/renderer/config/services/providerService.ts
+++ b/src/renderer/config/services/providerService.ts
@@ -3,7 +3,7 @@ import { exists, readDir, readTextFile, remove } from '@tauri-apps/plugin-fs';
 import { join } from '@tauri-apps/api/path';
 
 import type { Provider, ProviderVerifyStatus, AppConfig, Project } from '../types';
-import { PRESET_PROVIDERS } from '../types';
+import { PRESET_PROVIDERS, applyProviderEnablementAndOrder, isProviderEnabled } from '../types';
 import type { AgentConfig } from '../../../shared/types/agent';
 import {
     isBrowserDevMode,
@@ -208,7 +208,14 @@ export async function rebuildAndPersistAvailableProviders(): Promise<void> {
         ]);
         const verifyStatus = config.providerVerifyStatus ?? {};
 
-        const mergedProviders = mergePresetCustomModels(allProviders, config.presetCustomModels, config.presetRemovedModels as Record<string, string[]> | undefined);
+        const mergedProviders = applyProviderEnablementAndOrder(
+            mergePresetCustomModels(
+                allProviders,
+                config.presetCustomModels,
+                config.presetRemovedModels as Record<string, string[]> | undefined,
+            ),
+            config,
+        );
         // Apply user primary model overrides
         const primaryOverrides = config.providerPrimaryModels as Record<string, string> | undefined;
         // Only include providers with valid credentials:
@@ -253,6 +260,7 @@ export function isProviderAvailable(
     apiKeys: Record<string, string>,
     verifyStatus: Record<string, ProviderVerifyStatus>,
 ): boolean {
+    if (!isProviderEnabled(provider)) return false;
     if (provider.type === 'subscription') {
         const result = verifyStatus[provider.id];
         return result?.status === 'valid' && !!result?.accountEmail;

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, Download, FolderOpen, KeyRound, Link, Loader2, Plus, RefreshCw, Square, Trash2, Unlink, X, AlertCircle, Globe, ExternalLink as ExternalLinkIcon, Settings2 } from 'lucide-react';
+import { Check, ChevronDown, Download, FolderOpen, KeyRound, Link, Loader2, Plus, RefreshCw, SlidersHorizontal, Square, Trash2, Unlink, X, AlertCircle, Globe, ExternalLink as ExternalLinkIcon, Settings2 } from 'lucide-react';
 import { ExternalLink } from '@/components/ExternalLink';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getVersion } from '@tauri-apps/api/app';
@@ -23,6 +23,9 @@ import ModelManagementPanel from '@/components/ModelManagementPanel';
 import UsageStatsPanel from '@/components/UsageStatsPanel';
 import {
     getEffectiveModelAliases,
+    normalizeDisabledProviderIds,
+    normalizeProviderOrder,
+    type AppConfig,
     type ModelAliases,
     type Provider,
     type ProviderAuthType,
@@ -48,6 +51,7 @@ import {
     getMcpServerEnv,
     atomicModifyConfig,
     isProviderAvailable,
+    rebuildAndPersistAvailableProviders,
 } from '@/config/configService';
 import { useConfig } from '@/hooks/useConfig';
 import { useHelperAgentModelDefaults } from '@/hooks/useHelperAgentModelDefaults';
@@ -67,6 +71,7 @@ import { shortenPathForDisplay } from '@/utils/pathDetection';
 import type { LogEntry } from '@/types/log';
 import BugReportOverlay from '@/components/BugReportOverlay';
 import SettingsHelperInbox from '@/components/SettingsHelperInbox';
+import ProviderEnableOrderDialog from '@/components/ProviderEnableOrderDialog';
 
 /** Parse a string as a positive integer, returning undefined for invalid/non-positive values */
 function parsePositiveInt(value: string): number | undefined {
@@ -278,6 +283,9 @@ export default function Settings({ initialSection, initialMcpId, initialSelect, 
 
     const [showCustomForm, setShowCustomForm] = useState(false);
     const [customForm, setCustomForm] = useState<CustomProviderForm>(EMPTY_CUSTOM_FORM);
+    const [showProviderOrderDialog, setShowProviderOrderDialog] = useState(false);
+    const [providerOrderDraft, setProviderOrderDraft] = useState<string[]>([]);
+    const [disabledProviderDraft, setDisabledProviderDraft] = useState<string[]>([]);
     const customModelInputRef = useRef<HTMLInputElement>(null);
     const addCustomModelFromInput = () => {
         const val = customModelInputRef.current?.value.trim();
@@ -667,6 +675,7 @@ export default function Settings({ initialSection, initialMcpId, initialSelect, 
         // z-50: all other inline overlays
         if (runtimeDialog.show) { setRuntimeDialog(prev => ({ ...prev, show: false })); return true; }
         if (editingProvider) { setEditingProvider(null); return true; }
+        if (showProviderOrderDialog) { setShowProviderOrderDialog(false); return true; }
         if (showCustomForm) { setShowCustomForm(false); return true; }
         if (showMcpForm) { setShowMcpForm(false); setEditingMcpId(null); return true; }
         if (builtinMcpSettings) { setBuiltinMcpSettings(null); return true; }
@@ -2041,6 +2050,41 @@ export default function Settings({ initialSection, initialMcpId, initialSelect, 
 
     // providers from useConfig includes both preset and custom providers
     const allProviders = providers;
+    const visibleProviders = useMemo(
+        () => providers.filter(provider => provider.enabled !== false),
+        [providers],
+    );
+
+    const openProviderOrderDialog = useCallback(() => {
+        setProviderOrderDraft(allProviders.map(provider => provider.id));
+        setDisabledProviderDraft(allProviders
+            .filter(provider => provider.enabled === false)
+            .map(provider => provider.id));
+        setShowProviderOrderDialog(true);
+    }, [allProviders]);
+
+    const saveProviderOrderSettings = useCallback(async () => {
+        const providerIds = allProviders.map(provider => provider.id);
+        const nextOrder = normalizeProviderOrder(providerIds, providerOrderDraft);
+        const nextDisabled = normalizeDisabledProviderIds(providerIds, disabledProviderDraft);
+        const updates: Partial<AppConfig> = {
+            providerOrder: nextOrder,
+            disabledProviderIds: nextDisabled.length > 0 ? nextDisabled : undefined,
+        };
+        if (config.defaultProviderId && nextDisabled.includes(config.defaultProviderId)) {
+            updates.defaultProviderId = undefined;
+        }
+
+        try {
+            await updateConfig(updates);
+            await rebuildAndPersistAvailableProviders();
+            setShowProviderOrderDialog(false);
+            toast.success('供应商启用和排序已保存');
+        } catch (error) {
+            console.error('[Settings] Failed to save provider order settings:', error);
+            toast.error('保存供应商启用和排序失败');
+        }
+    }, [allProviders, config.defaultProviderId, disabledProviderDraft, providerOrderDraft, toast, updateConfig]);
 
     // Refs for API Key expiry check (P2 fix - avoid stale closures)
     const allProvidersRef = useRef(allProviders);
@@ -2055,6 +2099,7 @@ export default function Settings({ initialSection, initialMcpId, initialSelect, 
         // Delay to let component stabilize
         const timer = setTimeout(() => {
             allProvidersRef.current.forEach((provider: Provider) => {
+                if (provider.enabled === false) return;
                 // Skip subscription type (handled separately)
                 if (provider.type === 'subscription') return;
 
@@ -2316,13 +2361,22 @@ export default function Settings({ initialSection, initialMcpId, initialSelect, 
                         )}
                         <div className="mb-8 flex items-center justify-between">
                             <h2 className="text-lg font-semibold text-[var(--ink)]">模型供应商</h2>
-                            <button
-                                onClick={() => setShowCustomForm(true)}
-                                className="flex items-center gap-1.5 rounded-lg bg-[var(--button-primary-bg)] px-3 py-1.5 text-sm font-medium text-[var(--button-primary-text)] transition-colors hover:bg-[var(--button-primary-bg-hover)]"
-                            >
-                                <Plus className="h-3.5 w-3.5" />
-                                添加
-                            </button>
+                            <div className="flex items-center gap-2">
+                                <button
+                                    onClick={openProviderOrderDialog}
+                                    className="flex items-center gap-1.5 rounded-lg border border-[var(--line)] px-3 py-1.5 text-sm font-medium text-[var(--ink)] transition-colors hover:bg-[var(--paper-inset)]"
+                                >
+                                    <SlidersHorizontal className="h-3.5 w-3.5" />
+                                    启用和排序
+                                </button>
+                                <button
+                                    onClick={() => setShowCustomForm(true)}
+                                    className="flex items-center gap-1.5 rounded-lg bg-[var(--button-primary-bg)] px-3 py-1.5 text-sm font-medium text-[var(--button-primary-text)] transition-colors hover:bg-[var(--button-primary-bg-hover)]"
+                                >
+                                    <Plus className="h-3.5 w-3.5" />
+                                    添加
+                                </button>
+                            </div>
                         </div>
 
                         <p className="mb-6 text-sm text-[var(--ink-muted)]">
@@ -2331,7 +2385,7 @@ export default function Settings({ initialSection, initialMcpId, initialSelect, 
 
                         {/* Provider list */}
                         <div className="grid grid-cols-2 gap-4">
-                            {allProviders.map((provider) => (
+                            {visibleProviders.map((provider) => (
                                 <div
                                     key={provider.id}
                                     className="min-w-0 rounded-xl border border-[var(--line)] bg-[var(--paper-elevated)] p-5"
@@ -2468,6 +2522,12 @@ export default function Settings({ initialSection, initialMcpId, initialSelect, 
                                     )}
                                 </div>
                             ))}
+                            {visibleProviders.length === 0 && (
+                                <div className="col-span-2 rounded-xl border border-dashed border-[var(--line)] bg-[var(--paper-elevated)] p-8 text-center">
+                                    <p className="text-sm font-medium text-[var(--ink)]">没有已启用的供应商</p>
+                                    <p className="mt-1 text-xs text-[var(--ink-muted)]">打开“启用和排序”重新启用供应商。</p>
+                                </div>
+                            )}
                         </div>
                     </div>
                 )}
@@ -4925,6 +4985,19 @@ export default function Settings({ initialSection, initialMcpId, initialSelect, 
                         )}
                     </div>
                 </OverlayBackdrop>
+            )}
+
+            {/* Provider Enablement / Ordering Modal */}
+            {showProviderOrderDialog && (
+                <ProviderEnableOrderDialog
+                    providers={allProviders}
+                    providerOrderDraft={providerOrderDraft}
+                    disabledProviderDraft={disabledProviderDraft}
+                    onProviderOrderDraftChange={setProviderOrderDraft}
+                    onDisabledProviderDraftChange={setDisabledProviderDraft}
+                    onClose={() => setShowProviderOrderDialog(false)}
+                    onSave={saveProviderOrderSettings}
+                />
             )}
 
             {/* Custom Provider Modal */}

--- a/src/server/__tests__/provider-enablement.test.ts
+++ b/src/server/__tests__/provider-enablement.test.ts
@@ -1,0 +1,84 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let scratch: string;
+let prevHome: string | undefined;
+let prevUserProfile: string | undefined;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'myagents-provider-enable-'));
+  const configDir = join(scratch, '.myagents');
+  const providersDir = join(configDir, 'providers');
+  mkdirSync(providersDir, { recursive: true });
+
+  prevHome = process.env.HOME;
+  prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = scratch;
+  process.env.USERPROFILE = scratch;
+});
+
+afterEach(() => {
+  process.env.HOME = prevHome;
+  process.env.USERPROFILE = prevUserProfile;
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+function writeCustomProvider(id: string): void {
+  writeFileSync(
+    join(scratch, '.myagents', 'providers', `${id}.json`),
+    JSON.stringify({
+      id,
+      name: 'Custom Provider',
+      vendor: 'Custom',
+      cloudProvider: 'Custom',
+      type: 'api',
+      primaryModel: 'custom-model',
+      isBuiltin: false,
+      authType: 'api_key',
+      config: {
+        baseUrl: 'https://custom.example/v1',
+      },
+      models: [
+        { model: 'custom-model', modelName: 'Custom Model', modelSeries: 'custom' },
+      ],
+    }, null, 2),
+    'utf-8',
+  );
+}
+
+describe('server-side provider enablement', () => {
+  it('does not resolve disabled providers for background runtime startup', async () => {
+    const { resolveProviderEnv, resolveWorkspaceConfig } = await import('../utils/admin-config');
+    const providerId = 'custom-disabled';
+    const workspacePath = join(scratch, 'workspace');
+    writeCustomProvider(providerId);
+
+    writeFileSync(
+      join(scratch, '.myagents', 'config.json'),
+      JSON.stringify({
+        providerApiKeys: {
+          [providerId]: 'provider-secret',
+        },
+        disabledProviderIds: [providerId],
+        agents: [
+          {
+            id: 'agent-1',
+            name: 'Agent',
+            enabled: true,
+            workspacePath,
+            providerId,
+          },
+        ],
+      }, null, 2),
+      'utf-8',
+    );
+    writeFileSync(join(scratch, '.myagents', 'projects.json'), '[]', 'utf-8');
+
+    expect(resolveProviderEnv(providerId)).toBeUndefined();
+    const resolved = resolveWorkspaceConfig(workspacePath);
+    expect(resolved.providerEnv).toBeUndefined();
+    expect(resolved.model).toBeUndefined();
+  });
+});

--- a/src/server/admin-api.ts
+++ b/src/server/admin-api.ts
@@ -11,7 +11,6 @@
  */
 
 import type { McpServerDefinition } from '../shared/config-types';
-import { PRESET_PROVIDERS } from '../shared/config-types';
 import { SDK_RESERVED_MCP_NAMES } from './agent-session';
 import {
   loadConfig,
@@ -22,8 +21,9 @@ import {
   saveProjects,
   redactSecret,
   findProvider,
+  getAllEffectiveProviders,
+  isProviderDisabled,
   getProvidersDir,
-  loadCustomProviderFiles,
   type AdminAppConfig,
   type AgentConfigSlim,
   type ChannelConfigSlim,
@@ -765,17 +765,7 @@ export function handleModelList(): AdminResponse {
   const apiKeys = config.providerApiKeys ?? {};
   const verifyStatus = config.providerVerifyStatus ?? {};
 
-  // Load preset providers (statically imported — see top of file).
-  // Cast via `unknown` because `Provider` doesn't carry a string index
-  // signature; the downstream loop accesses fields by name through `String(p.id)`
-  // and `p.config as Record<string, unknown> | undefined`, which works on
-  // both shapes uniformly.
-  const presetProviders: Array<Record<string, unknown>> = (PRESET_PROVIDERS ?? []) as unknown as Array<Record<string, unknown>>;
-
-  // Load custom providers
-  const customProviders = loadCustomProviderFiles();
-
-  const allProviders = [...presetProviders, ...customProviders];
+  const allProviders = getAllEffectiveProviders(config);
   const data = allProviders.map(p => {
     const id = String(p.id);
     const cfg = p.config as Record<string, unknown> | undefined;
@@ -786,6 +776,7 @@ export function handleModelList(): AdminResponse {
       baseUrl: cfg?.baseUrl ? String(cfg.baseUrl) : undefined,
       isBuiltin: !!p.isBuiltin,
       protocol: p.apiProtocol ? String(p.apiProtocol) : 'anthropic',
+      enabled: p.enabled !== false,
       hasApiKey: !!apiKeys[id],
       status: (verifyStatus[id] as Record<string, unknown>)?.status ?? 'not-set',
     };
@@ -811,6 +802,9 @@ export async function handleModelSetKey(payload: { id: string; apiKey: string })
 export async function handleModelSetDefault(payload: { id: string }): Promise<AdminResponse> {
   const { id } = payload;
   if (!id) return { success: false, error: 'Missing required field: id' };
+  if (isProviderDisabled(id)) {
+    return { success: false, error: `Provider '${id}' is disabled. Re-enable it before setting it as default.` };
+  }
 
   await atomicModifyConfig(c => ({
     ...c,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -518,7 +518,7 @@ import {
   updateSessionMetadata,
   getAttachmentPath,
 } from './SessionStore';
-import { findAgentByWorkspacePath, findProvider, getAllMcpServers, getEffectiveMcpServers, resolveProviderEnv } from './utils/admin-config';
+import { findAgentByWorkspacePath, findProvider, getAllMcpServers, getEffectiveMcpServers, isProviderDisabled, resolveProviderEnv } from './utils/admin-config';
 import { snapshotForOwnedSession } from './utils/session-snapshot';
 import { resolveSessionConfig } from './utils/resolve-session-config';
 import type { AgentConfig } from '../shared/types/agent';
@@ -666,6 +666,11 @@ function resolveCronProviderRouting(
   if (!provider) {
     throw new Error(
       `Provider '${providerId}' not found in config — task references a provider that has been deleted. Re-select a provider in 任务编辑 → 高级配置.`,
+    );
+  }
+  if (isProviderDisabled(providerId)) {
+    throw new Error(
+      `Provider '${providerId}' is disabled — re-enable it in 设置 → 模型供应商 → 启用和排序, or re-select a provider in 任务编辑 → 高级配置.`,
     );
   }
   if (provider.type === 'subscription') {

--- a/src/server/utils/admin-config.ts
+++ b/src/server/utils/admin-config.ts
@@ -22,7 +22,7 @@ import { resolve } from 'path';
 import { getHomeDirOrNull } from './platform';
 import { stripBom } from '../../shared/utils';
 import type { McpServerDefinition } from '../../shared/config-types';
-import { PRESET_MCP_SERVERS, PRESET_PROVIDERS } from '../../shared/config-types';
+import { applyProviderEnablementAndOrder, isProviderEnabled, PRESET_MCP_SERVERS, PRESET_PROVIDERS } from '../../shared/config-types';
 import type { SessionMetadata } from '../types/session';
 import { ensureDirSync } from './fs-utils';
 import { withFileLock, FileBusyError } from './file-lock';
@@ -72,6 +72,8 @@ export interface AdminAppConfig {
   defaultProviderId?: string;
   providerApiKeys?: Record<string, string>;
   providerVerifyStatus?: Record<string, { status: string; verifiedAt?: string }>;
+  providerOrder?: string[];
+  disabledProviderIds?: string[];
   // Agent
   agents?: AgentConfigSlim[];
   // Allow passthrough of all other fields
@@ -376,6 +378,30 @@ export function loadCustomProviderFiles(): Array<Record<string, unknown>> {
   } catch { return []; }
 }
 
+type ProviderRecord = Record<string, unknown> & { id: string; enabled?: unknown };
+
+function hasProviderId(provider: Record<string, unknown>): provider is ProviderRecord {
+  return typeof provider.id === 'string' && provider.id.length > 0;
+}
+
+export function getAllEffectiveProviders(config?: AdminAppConfig): ProviderRecord[] {
+  const c = config ?? loadConfig();
+  const presetProviders = ((PRESET_PROVIDERS ?? []) as unknown as Array<Record<string, unknown>>)
+    .filter(hasProviderId);
+  const customProviders = loadCustomProviderFiles().filter(hasProviderId);
+  return applyProviderEnablementAndOrder([...presetProviders, ...customProviders], c);
+}
+
+export function findEffectiveProvider(id: string, config?: AdminAppConfig): ProviderRecord | null {
+  if (!id) return null;
+  return getAllEffectiveProviders(config).find(provider => provider.id === id) ?? null;
+}
+
+export function isProviderDisabled(providerId: string, config?: AdminAppConfig): boolean {
+  const provider = findEffectiveProvider(providerId, config);
+  return !!provider && !isProviderEnabled(provider);
+}
+
 // ---------------------------------------------------------------------------
 // Provider resolution (Sidecar self-resolve — eliminates dependency on providerEnvJson snapshots)
 // ---------------------------------------------------------------------------
@@ -404,8 +430,10 @@ export function resolveProviderEnv(
 ): ResolvedProviderEnv | undefined {
   if (!providerId) return undefined;
 
-  const provider = findProvider(providerId);
+  const c = config ?? loadConfig();
+  const provider = findEffectiveProvider(providerId, c);
   if (!provider) return undefined;
+  if (!isProviderEnabled(provider)) return undefined;
 
   // Subscription providers don't use providerEnv (SDK uses built-in OAuth)
   if (provider.type === 'subscription') return undefined;
@@ -414,7 +442,6 @@ export function resolveProviderEnv(
   // (Codex review): a value like `"  "` is truthy and would silently be
   // sent to the upstream as the Authorization header, producing an opaque
   // 401 instead of an actionable "no API key" error.
-  const c = config ?? loadConfig();
   const apiKey = (c.providerApiKeys ?? {})[providerId];
   if (!apiKey || !apiKey.trim()) return undefined;
 
@@ -573,8 +600,8 @@ export function resolveWorkspaceConfig(
   // Priority: session.model → agent.model → provider's primaryModel (if resolved)
   let model = sessionMeta?.model ?? (agent?.model as string | undefined) ?? undefined;
   if (!model && providerId) {
-    const provider = findProvider(providerId);
-    if (provider) {
+    const provider = findEffectiveProvider(providerId, config);
+    if (provider && isProviderEnabled(provider)) {
       model = (provider as Record<string, unknown>).primaryModel as string | undefined;
     }
   }

--- a/src/shared/config-types.ts
+++ b/src/shared/config-types.ts
@@ -75,6 +75,75 @@ export interface ModelAliases {
   haiku?: string;   // e.g., 'deepseek-chat'
 }
 
+export interface ProviderOrderSettings {
+  providerOrder?: string[];
+  disabledProviderIds?: string[];
+}
+
+type ProviderOrderable = {
+  id: string;
+  enabled?: unknown;
+};
+
+export function normalizeProviderOrder(providerIds: string[], providerOrder?: string[]): string[] {
+  const known = new Set(providerIds);
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const id of providerOrder ?? []) {
+    if (!known.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    ordered.push(id);
+  }
+
+  for (const id of providerIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    ordered.push(id);
+  }
+
+  return ordered;
+}
+
+export function normalizeDisabledProviderIds(providerIds: string[], disabledProviderIds?: string[]): string[] {
+  const known = new Set(providerIds);
+  const seen = new Set<string>();
+  const disabled: string[] = [];
+
+  for (const id of disabledProviderIds ?? []) {
+    if (!known.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    disabled.push(id);
+  }
+
+  return disabled;
+}
+
+export function applyProviderEnablementAndOrder<T extends ProviderOrderable>(
+  providers: T[],
+  settings?: ProviderOrderSettings,
+): T[] {
+  const byId = new Map(providers.map(provider => [provider.id, provider] as const));
+  const orderedIds = normalizeProviderOrder(providers.map(provider => provider.id), settings?.providerOrder);
+  const disabled = new Set(normalizeDisabledProviderIds(orderedIds, settings?.disabledProviderIds));
+
+  return orderedIds
+    .map(id => {
+      const provider = byId.get(id);
+      if (!provider) return undefined;
+      const nextEnabled = !disabled.has(id);
+      if (provider.enabled === nextEnabled || (nextEnabled && provider.enabled === undefined)) {
+        return provider;
+      }
+      return { ...provider, enabled: nextEnabled };
+    })
+    .filter((provider): provider is T => Boolean(provider));
+}
+
+export function isProviderEnabled(provider: { enabled?: unknown } | null | undefined): boolean {
+  return provider?.enabled !== false;
+}
+
 /**
  * Get the display name for a model
  */
@@ -141,6 +210,7 @@ export interface Provider {
   type: 'subscription' | 'api';
   primaryModel: string;     // 默认模型 API 代码
   isBuiltin: boolean;
+  enabled?: boolean;        // Runtime-derived: false when globally disabled by the user
 
   // API 配置
   config: {
@@ -352,6 +422,12 @@ export interface AppConfig {
   // ===== Provider Model Aliases (user overrides) =====
   // Maps provider ID → user-configured model alias overrides (merged with preset defaults)
   providerModelAliases?: Record<string, ModelAliases>;
+
+  // ===== Provider Enablement / Ordering =====
+  // Provider IDs in user-defined display/fallback order.
+  providerOrder?: string[];
+  // Provider IDs hidden from selectors and runtime resolution without deleting their settings.
+  disabledProviderIds?: string[];
 
   // ===== MCP Configuration =====
   // Custom MCP servers added by user (merged with presets)


### PR DESCRIPTION
## Summary
- add provider enablement/order settings and a Settings dialog for reordering and hiding providers
- apply the configured order across provider fallback, available-provider cache, admin model list, and server-side provider resolution
- block disabled providers from background task routing while preserving existing provider config and API keys

## Testing
- npm test -- src/renderer/config/providerEnablement.test.ts src/renderer/config/services/providerService.test.ts src/server/__tests__/provider-enablement.test.ts
- npm run typecheck
- npm run lint:deps
- npm run build:server
- npm run build:web