### PR TITLE
feat: prefer 00-CORE.md lightweight core memory over full ruleset

### DIFF
--- a/src/server/runtimes/workspace-instructions.ts
+++ b/src/server/runtimes/workspace-instructions.ts
@@ -186,8 +186,11 @@ function collectRuleFiles(
 // ─── Core read functions ───
 
 /**
- * Read CLAUDE.md + .claude/CLAUDE.md + .claude/rules/*.md from a workspace.
- * Shares a single CollectBudget so the aggregate cap spans all three sources.
+ * Read 00-CORE.md (lightweight core memory) if present, otherwise fall back to
+ * CLAUDE.md + .claude/CLAUDE.md + .claude/rules/*.md.
+ *
+ * 00-CORE.md is a user-maintained ~200-token distillation of the full ruleset.
+ * When it exists we skip the heavy files to cut per-request fixed overhead.
  */
 function readClaudeWorkspaceInstructions(workspacePath: string): WorkspaceInstruction[] {
   const instructions: WorkspaceInstruction[] = [];
@@ -204,6 +207,14 @@ function readClaudeWorkspaceInstructions(workspacePath: string): WorkspaceInstru
     budget.totalBytes += size;
   };
 
+  // Phase-1 optimization: prefer 00-CORE.md (lightweight core memory)
+  const coreMemory = readIfExists(join(workspacePath, '.claude', 'rules', '00-CORE.md'));
+  if (coreMemory) {
+    consume(coreMemory);
+    return instructions; // skip heavy rules when core memory is present
+  }
+
+  // Fallback: load full rule set (legacy behaviour)
   // CLAUDE.md at project root
   consume(readIfExists(join(workspacePath, 'CLAUDE.md')));
 


### PR DESCRIPTION
## Summary

Phase-1 implementation of the context-layered optimization proposed in #240.

When `.claude/rules/00-CORE.md` exists, load it **instead of** the full `CLAUDE.md` + `.claude/rules/*.md` stack. This cuts per-request fixed overhead from ~2,000 tokens to ~200 tokens for users who maintain a distilled core memory file.

## Changes

- `src/server/runtimes/workspace-instructions.ts`: Added `00-CORE.md` detection before the legacy rule-loading path
- Backward compatible: falls back to existing behaviour when `00-CORE.md` is absent
- No breaking changes

## How to use

1. Create `.claude/rules/00-CORE.md` in your project
2. Distil your full ruleset into ~200 tokens of essential information
3. MyAgents will automatically prefer it over the heavy files

Example `00-CORE.md`:

```markdown
# CORE.md - 核心记忆（常驻，~200 tokens）

用户: [称呼]，中文，[风格偏好]。
职业: [职业背景]。
目标: [当前目标1]、[当前目标2]。

输出: [输出风格要求]。
工作流: [核心工作流1]→[工作流2]→[工作流3]。

敏感: [安全规则1]；[安全规则2]。
```

## Benchmark

| Scenario | Before | After | Reduction |
|----------|--------|-------|-----------|
| Full ruleset (5 files) | ~2,000 tokens | — | — |
| 00-CORE.md only | — | ~200 tokens | **90%** |

## Related

- RFC: #240
