### PR TITLE
feat: 将 Management API 端口写入 ~/.myagents/management.port

### DIFF
--- a/src-tauri/src/management_api.rs
+++ b/src-tauri/src/management_api.rs
@@ -69,6 +69,20 @@ fn get_sidecar_state() -> Option<&'static crate::sidecar::ManagedSidecarManager>
 
 /// Start the internal management API server on a random port
 /// Returns the port number for injection into Sidecar env vars
+
+/// Write the Management API port to ~/.myagents/management.port so external
+/// tools (session consoles, third-party frontends) can discover it.
+fn write_management_port_file(port: u16) {
+    if let Some(home) = dirs::home_dir() {
+        let port_file = home.join(".myagents").join("management.port");
+        if let Err(e) = std::fs::write(&port_file, port.to_string()) {
+            ulog_warn!("[mgmt-api] Failed to write management.port: {}", e);
+        } else {
+            ulog_info!("[mgmt-api] Wrote management.port = {}", port);
+        }
+    }
+}
+
 pub async fn start_management_api() -> Result<u16, String> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -82,6 +96,8 @@ pub async fn start_management_api() -> Result<u16, String> {
     MANAGEMENT_PORT
         .set(port)
         .map_err(|_| "Management API already started".to_string())?;
+
+    write_management_port_file(port);
 
     let app = Router::new()
         .route("/api/cron/create", post(create_cron_handler))


### PR DESCRIPTION
## 背景

我正在开发一个 **AI 会话聚合控制台**（Session Console），聚合 Claude Code、Codex、Cursor、MyAgents 等多个 AI 工具的会话数据，提供统一的浏览、搜索和续接能力。

MyAgents 的 session 数据我已经能读取（`~/.myagents/sessions/*.jsonl`），但**没法写入**——要给一个 session 发消息续接对话，必须通过 Rust 层的 Management API（`/api/inbox/deliver`）。

## 问题

Management API 端口是 MyAgents 启动时随机分配的，目前只存在两处：

1. Rust 内存（`OnceLock<u16>`）
2. 子 Sidecar 进程的环境变量（`MYAGENTS_MANAGEMENT_PORT`）

外部工具（非 Sidecar 子进程）无法获取这个端口号。

而 Global Sidecar 端口已经通过 `~/.myagents/sidecar.port` 暴露了，Management API 端口却没有对应的文件。

## 改动

在 `start_management_api()` 中，端口分配成功后写入 `~/.myagents/management.port`，然后你的外部工具就可以读取它了。

新增 `write_management_port_file()` 函数，逻辑完全参照 `sidecar.rs` 中已有的 `write_global_port_file()`。

## 改动范围

仅 `src-tauri/src/management_api.rs`，新增 14 行，无破坏性变更。

## 使用场景

外部工具拿到端口后，可以直接调用 Management API：

```bash
PORT=$(cat ~/.myagents/management.port)
curl -X POST "http://127.0.0.1:$PORT/api/inbox/deliver" \
  -H "Content-Type: application/json" \
  -d '{
    "message": {
      "messageId": "...",
      "fromSessionId": "session-console",
      "fromLabel": "Session Console",
      "toSessionId": "<目标 session ID>",
      "text": "继续上次的任务",
      "replyBack": false
    },
    "resumeWorkspacePath": "/path/to/workspace"
  }'
```

Management API 会自动处理 session 复活、端口路由、消息注入——外部工具不需要关心这些细节。

🤖 Generated with [Claude Code](https://claude.com/claude-code)