### PR TITLE
feat(ui): add sage and purple color themes

### DIFF
--- a/src/renderer/config/services/appConfigService.ts
+++ b/src/renderer/config/services/appConfigService.ts
@@ -10,6 +10,7 @@ import {
     getSystemPresetProjectMetadataPatch,
     mergePresetModelWithCustomEntry,
     normalizeClaudeTranscriptCleanupPeriodDays,
+    normalizeColorTheme,
 } from '../types';
 import {
     isBrowserDevMode,
@@ -109,6 +110,7 @@ export function migrateImBotConfig(config: AppConfig): AppConfig {
 }
 
 function normalizeDeveloperSettings(config: AppConfig): AppConfig {
+    config.colorTheme = normalizeColorTheme(config.colorTheme);
     config.uiLanguage = normalizeUiLanguage(config.uiLanguage);
     config.claudeTranscriptCleanupPeriodDays = normalizeClaudeTranscriptCleanupPeriodDays(
         config.claudeTranscriptCleanupPeriodDays,

--- a/src/renderer/hooks/useTheme.ts
+++ b/src/renderer/hooks/useTheme.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useConfig } from './useConfig';
+import { normalizeColorTheme } from '@/config/types';
 
 /**
  * Applies the theme to the document based on config.theme ('light' | 'dark' | 'system').
@@ -10,6 +11,7 @@ import { useConfig } from './useConfig';
 export function useThemeEffect(): void {
   const { config } = useConfig();
   const theme = config.theme ?? 'system';
+  const colorTheme = normalizeColorTheme(config.colorTheme);
 
   useEffect(() => {
     const html = document.documentElement;
@@ -37,4 +39,14 @@ export function useThemeEffect(): void {
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }, [theme]);
+
+  useEffect(() => {
+    const html = document.documentElement;
+    if (colorTheme === 'warm') {
+      html.removeAttribute('data-color-theme');
+    } else {
+      html.setAttribute('data-color-theme', colorTheme);
+    }
+    try { localStorage.setItem('colorTheme', colorTheme); } catch { /* ignore */ }
+  }, [colorTheme]);
 }

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -49,6 +49,12 @@
       "light": "Light",
       "dark": "Dark"
     },
+    "colorThemeTitle": "Color theme",
+    "colorThemeDescription": "Switch the app-wide interface palette",
+    "colorTheme": {
+      "warm": "Warm paper",
+      "sage": "Sage"
+    },
     "queueTitle": "Queued messages",
     "queueModeTitle": "Queue response mode",
     "queueTurnDescription": "Send the next queued message only after AI finishes the current turn",

--- a/src/renderer/i18n/locales/en-US/settings.json
+++ b/src/renderer/i18n/locales/en-US/settings.json
@@ -53,7 +53,9 @@
     "colorThemeDescription": "Switch the app-wide interface palette",
     "colorTheme": {
       "warm": "Warm paper",
-      "sage": "Sage"
+      "sage": "Sage",
+      "mauve": "Mauve",
+      "wisteria": "Wisteria"
     },
     "queueTitle": "Queued messages",
     "queueModeTitle": "Queue response mode",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -49,6 +49,12 @@
       "light": "日间模式",
       "dark": "夜间模式"
     },
+    "colorThemeTitle": "颜色皮肤",
+    "colorThemeDescription": "切换整个软件的界面配色",
+    "colorTheme": {
+      "warm": "暖纸",
+      "sage": "鼠尾草"
+    },
     "queueTitle": "连续发送消息",
     "queueModeTitle": "队列响应模式",
     "queueTurnDescription": "仅在 AI 完成一个执行轮次后，自动发送下一条消息",

--- a/src/renderer/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/i18n/locales/zh-CN/settings.json
@@ -53,7 +53,9 @@
     "colorThemeDescription": "切换整个软件的界面配色",
     "colorTheme": {
       "warm": "暖纸",
-      "sage": "鼠尾草"
+      "sage": "鼠尾草",
+      "mauve": "灰紫",
+      "wisteria": "藤紫"
     },
     "queueTitle": "连续发送消息",
     "queueModeTitle": "队列响应模式",

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -610,6 +610,348 @@
   --toggle-off-bg: rgb(220 232 215 / 0.18);
 }
 
+/* ============================================================
+   Color Theme — "Mauve" (灰紫)
+   Low-saturation purple with a mature, document-friendly feel.
+   ============================================================ */
+[data-color-theme="mauve"]:not(.dark) {
+  --ink: #201820;
+  --ink-secondary: #3a3039;
+  --ink-muted: #756875;
+  --ink-subtle: #aaa0a9;
+  --ink-faint: #c6bdc5;
+
+  --paper: #f8f4f7;
+  --paper-elevated: #fffafd;
+  --message-user-bg: #fffafd;
+  --paper-inset: #eadfe8;
+  --paper-a0: rgb(248 244 247 / 0);
+  --paper-elevated-a0: rgb(255 250 253 / 0);
+  --message-user-bg-a0: rgb(255 250 253 / 0);
+  --paper-inset-a0: rgb(234 223 232 / 0);
+  --hover-bg: rgb(154 95 143 / 0.08);
+
+  --accent: #9a5f8f;
+  --accent-warm: #9a5f8f;
+  --accent-warm-hover: #b173a6;
+  --accent-warm-subtle: rgb(154 95 143 / 0.10);
+  --accent-warm-muted: rgb(154 95 143 / 0.18);
+  --accent-warm-subtle-a0: rgb(154 95 143 / 0);
+  --accent-cool: #6f6aa8;
+  --accent-cool-hover: #837dcc;
+
+  --heartbeat: #bd5a70;
+  --heartbeat-bg: rgb(189 90 112 / 0.10);
+  --heartbeat-border: rgb(189 90 112 / 0.20);
+
+  --success: #4f8a69;
+  --success-bg: #e0ede5;
+  --error: #c84f5b;
+  --error-bg: #f5dfe3;
+  --error-hover: #ad414c;
+  --error-subtle: rgb(200 79 91 / 0.08);
+  --warning: #a76d18;
+  --warning-bg: #f2e8c9;
+  --info: #5f789f;
+  --info-bg: #e2e8f0;
+
+  --button-primary-bg: #9a5f8f;
+  --button-primary-bg-hover: #884f7e;
+  --button-primary-text: #ffffff;
+  --button-dark-bg: #201820;
+  --button-dark-bg-hover: #3a3039;
+  --button-secondary-bg: #eadfe8;
+  --button-secondary-bg-hover: #dfd1dc;
+  --button-secondary-text: #201820;
+
+  --fb-surface-peek: rgb(252 247 251 / 0.16);
+  --fb-surface-glass: rgb(252 247 251 / 0.58);
+  --fb-surface-pin: rgb(252 247 251 / 0.96);
+  --fb-surface-pin-a0: rgb(252 247 251 / 0);
+  --fb-surface-pin-72: rgb(252 247 251 / 0.72);
+  --fb-surface-pin-95: rgb(252 247 251 / 0.95);
+  --fb-glass-border: rgb(255 255 255 / 0.64);
+  --fb-glass-border-soft: rgb(255 255 255 / 0.50);
+  --fb-shadow-strong: rgb(32 24 32 / 0.26);
+  --fb-shadow-soft: rgb(32 24 32 / 0.12);
+  --fb-shadow-preview: rgb(32 24 32 / 0.42);
+  --fb-core-shadow: rgb(32 24 32 / 0.22);
+  --fb-inset-shadow: rgb(32 24 32 / 0.08);
+  --fb-control-hover: rgb(32 24 32 / 0.06);
+  --fb-line-input: rgb(32 24 32 / 0.07);
+  --fb-line-thumb: rgb(32 24 32 / 0.12);
+  --fb-drag-handle: rgb(32 24 32 / 0.18);
+  --fb-scroll-thumb: rgb(170 160 169 / 0.52);
+
+  --line: rgb(32 24 32 / 0.10);
+  --line-strong: rgb(32 24 32 / 0.18);
+  --line-subtle: rgb(32 24 32 / 0.06);
+
+  --shadow-xs: 0 1px 2px rgb(32 24 32 / 0.05);
+  --shadow-sm: 0 2px 8px rgb(32 24 32 / 0.08);
+  --shadow-md: 0 8px 24px rgb(32 24 32 / 0.12);
+  --shadow-lg: 0 16px 40px rgb(32 24 32 / 0.16);
+  --shadow-xl: 0 24px 48px rgb(32 24 32 / 0.20);
+
+  --focus-border: #201820;
+  --toggle-off-bg: rgb(32 24 32 / 0.18);
+}
+
+.dark[data-color-theme="mauve"] {
+  --ink: #eadce8;
+  --ink-secondary: #d5c5d2;
+  --ink-muted: #a0939e;
+  --ink-subtle: #706370;
+  --ink-faint: #504750;
+
+  --paper: #191219;
+  --paper-elevated: #241a23;
+  --message-user-bg: #2c202b;
+  --paper-inset: #120d12;
+  --paper-a0: rgb(25 18 25 / 0);
+  --paper-elevated-a0: rgb(36 26 35 / 0);
+  --message-user-bg-a0: rgb(44 32 43 / 0);
+  --paper-inset-a0: rgb(18 13 18 / 0);
+  --hover-bg: rgb(193 138 183 / 0.13);
+
+  --accent: #c18ab7;
+  --accent-warm: #c18ab7;
+  --accent-warm-hover: #d29cc7;
+  --accent-warm-subtle: rgb(193 138 183 / 0.13);
+  --accent-warm-muted: rgb(193 138 183 / 0.22);
+  --accent-warm-subtle-a0: rgb(193 138 183 / 0);
+  --accent-cool: #9b96d4;
+  --accent-cool-hover: #aea8e6;
+
+  --heartbeat: #d8798b;
+  --heartbeat-bg: rgb(216 121 139 / 0.13);
+  --heartbeat-border: rgb(216 121 139 / 0.23);
+
+  --success: #78b58d;
+  --success-bg: rgb(120 181 141 / 0.16);
+  --error: #ef737c;
+  --error-bg: rgb(239 115 124 / 0.16);
+  --error-hover: #db626d;
+  --error-subtle: rgb(239 115 124 / 0.13);
+  --warning: #d8ad58;
+  --warning-bg: rgb(216 173 88 / 0.16);
+  --info: #8aa2d1;
+  --info-bg: rgb(138 162 209 / 0.16);
+
+  --button-primary-bg: #c18ab7;
+  --button-primary-bg-hover: #b079a6;
+  --button-primary-text: #140f14;
+  --button-dark-bg: #473a46;
+  --button-dark-bg-hover: #5a4a58;
+  --button-secondary-bg: #30242f;
+  --button-secondary-bg-hover: #3a2d39;
+  --button-secondary-text: #eadce8;
+
+  --fb-surface-peek: rgb(25 18 25 / 0.24);
+  --fb-surface-glass: rgb(36 26 35 / 0.60);
+  --fb-surface-pin: rgb(36 26 35 / 0.96);
+  --fb-surface-pin-a0: rgb(36 26 35 / 0);
+  --fb-surface-pin-72: rgb(36 26 35 / 0.72);
+  --fb-surface-pin-95: rgb(36 26 35 / 0.95);
+  --fb-glass-border: rgb(255 255 255 / 0.16);
+  --fb-glass-border-soft: rgb(255 255 255 / 0.12);
+  --fb-shadow-strong: rgb(0 0 0 / 0.38);
+  --fb-shadow-soft: rgb(0 0 0 / 0.22);
+  --fb-shadow-preview: rgb(0 0 0 / 0.55);
+  --fb-core-shadow: rgb(0 0 0 / 0.32);
+  --fb-inset-shadow: rgb(0 0 0 / 0.16);
+  --fb-control-hover: rgb(255 255 255 / 0.08);
+  --fb-line-input: rgb(234 220 232 / 0.08);
+  --fb-line-thumb: rgb(234 220 232 / 0.16);
+  --fb-drag-handle: rgb(234 220 232 / 0.20);
+  --fb-scroll-thumb: rgb(160 147 158 / 0.56);
+
+  --line: rgb(234 220 232 / 0.10);
+  --line-strong: rgb(234 220 232 / 0.18);
+  --line-subtle: rgb(234 220 232 / 0.06);
+
+  --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.12);
+  --shadow-sm: 0 2px 8px rgb(0 0 0 / 0.18);
+  --shadow-md: 0 8px 24px rgb(0 0 0 / 0.28);
+  --shadow-lg: 0 16px 40px rgb(0 0 0 / 0.35);
+  --shadow-xl: 0 24px 48px rgb(0 0 0 / 0.42);
+
+  --focus-border: var(--accent);
+  --toggle-thumb: #eadce8;
+  --toggle-off-bg: rgb(234 220 232 / 0.18);
+}
+
+/* ============================================================
+   Color Theme — "Wisteria" (藤紫)
+   Lighter blue-purple with a soft, airy reading surface.
+   ============================================================ */
+[data-color-theme="wisteria"]:not(.dark) {
+  --ink: #1e1a24;
+  --ink-secondary: #352f40;
+  --ink-muted: #70687c;
+  --ink-subtle: #a49ab2;
+  --ink-faint: #c0b7ca;
+
+  --paper: #f7f4fb;
+  --paper-elevated: #fffaff;
+  --message-user-bg: #fffaff;
+  --paper-inset: #e7dff2;
+  --paper-a0: rgb(247 244 251 / 0);
+  --paper-elevated-a0: rgb(255 250 255 / 0);
+  --message-user-bg-a0: rgb(255 250 255 / 0);
+  --paper-inset-a0: rgb(231 223 242 / 0);
+  --hover-bg: rgb(138 111 200 / 0.08);
+
+  --accent: #8a6fc8;
+  --accent-warm: #8a6fc8;
+  --accent-warm-hover: #9c82d8;
+  --accent-warm-subtle: rgb(138 111 200 / 0.10);
+  --accent-warm-muted: rgb(138 111 200 / 0.18);
+  --accent-warm-subtle-a0: rgb(138 111 200 / 0);
+  --accent-cool: #5f83b7;
+  --accent-cool-hover: #7096cc;
+
+  --heartbeat: #bd678c;
+  --heartbeat-bg: rgb(189 103 140 / 0.10);
+  --heartbeat-border: rgb(189 103 140 / 0.20);
+
+  --success: #548c72;
+  --success-bg: #e0ede8;
+  --error: #c85568;
+  --error-bg: #f5e0e5;
+  --error-hover: #ad4658;
+  --error-subtle: rgb(200 85 104 / 0.08);
+  --warning: #a7741c;
+  --warning-bg: #f2e9ce;
+  --info: #567da8;
+  --info-bg: #e0e8f2;
+
+  --button-primary-bg: #8a6fc8;
+  --button-primary-bg-hover: #785eb6;
+  --button-primary-text: #ffffff;
+  --button-dark-bg: #1e1a24;
+  --button-dark-bg-hover: #352f40;
+  --button-secondary-bg: #e7dff2;
+  --button-secondary-bg-hover: #dcd2eb;
+  --button-secondary-text: #1e1a24;
+
+  --fb-surface-peek: rgb(251 248 255 / 0.16);
+  --fb-surface-glass: rgb(251 248 255 / 0.58);
+  --fb-surface-pin: rgb(251 248 255 / 0.96);
+  --fb-surface-pin-a0: rgb(251 248 255 / 0);
+  --fb-surface-pin-72: rgb(251 248 255 / 0.72);
+  --fb-surface-pin-95: rgb(251 248 255 / 0.95);
+  --fb-glass-border: rgb(255 255 255 / 0.64);
+  --fb-glass-border-soft: rgb(255 255 255 / 0.50);
+  --fb-shadow-strong: rgb(30 26 36 / 0.26);
+  --fb-shadow-soft: rgb(30 26 36 / 0.12);
+  --fb-shadow-preview: rgb(30 26 36 / 0.42);
+  --fb-core-shadow: rgb(30 26 36 / 0.22);
+  --fb-inset-shadow: rgb(30 26 36 / 0.08);
+  --fb-control-hover: rgb(30 26 36 / 0.06);
+  --fb-line-input: rgb(30 26 36 / 0.07);
+  --fb-line-thumb: rgb(30 26 36 / 0.12);
+  --fb-drag-handle: rgb(30 26 36 / 0.18);
+  --fb-scroll-thumb: rgb(164 154 178 / 0.52);
+
+  --line: rgb(30 26 36 / 0.10);
+  --line-strong: rgb(30 26 36 / 0.18);
+  --line-subtle: rgb(30 26 36 / 0.06);
+
+  --shadow-xs: 0 1px 2px rgb(30 26 36 / 0.05);
+  --shadow-sm: 0 2px 8px rgb(30 26 36 / 0.08);
+  --shadow-md: 0 8px 24px rgb(30 26 36 / 0.12);
+  --shadow-lg: 0 16px 40px rgb(30 26 36 / 0.16);
+  --shadow-xl: 0 24px 48px rgb(30 26 36 / 0.20);
+
+  --focus-border: #1e1a24;
+  --toggle-off-bg: rgb(30 26 36 / 0.18);
+}
+
+.dark[data-color-theme="wisteria"] {
+  --ink: #e4dcf0;
+  --ink-secondary: #cec3df;
+  --ink-muted: #9b91ad;
+  --ink-subtle: #695f7a;
+  --ink-faint: #4b4358;
+
+  --paper: #15121c;
+  --paper-elevated: #201a2a;
+  --message-user-bg: #282134;
+  --paper-inset: #0f0c14;
+  --paper-a0: rgb(21 18 28 / 0);
+  --paper-elevated-a0: rgb(32 26 42 / 0);
+  --message-user-bg-a0: rgb(40 33 52 / 0);
+  --paper-inset-a0: rgb(15 12 20 / 0);
+  --hover-bg: rgb(168 145 226 / 0.13);
+
+  --accent: #a891e2;
+  --accent-warm: #a891e2;
+  --accent-warm-hover: #baa5ef;
+  --accent-warm-subtle: rgb(168 145 226 / 0.13);
+  --accent-warm-muted: rgb(168 145 226 / 0.22);
+  --accent-warm-subtle-a0: rgb(168 145 226 / 0);
+  --accent-cool: #86a7dc;
+  --accent-cool-hover: #98b9ed;
+
+  --heartbeat: #d77ca2;
+  --heartbeat-bg: rgb(215 124 162 / 0.13);
+  --heartbeat-border: rgb(215 124 162 / 0.23);
+
+  --success: #7db69a;
+  --success-bg: rgb(125 182 154 / 0.16);
+  --error: #ef7b8c;
+  --error-bg: rgb(239 123 140 / 0.16);
+  --error-hover: #db6a7d;
+  --error-subtle: rgb(239 123 140 / 0.13);
+  --warning: #d8b160;
+  --warning-bg: rgb(216 177 96 / 0.16);
+  --info: #8eb1e2;
+  --info-bg: rgb(142 177 226 / 0.16);
+
+  --button-primary-bg: #a891e2;
+  --button-primary-bg-hover: #9780d0;
+  --button-primary-text: #111019;
+  --button-dark-bg: #40384f;
+  --button-dark-bg-hover: #514663;
+  --button-secondary-bg: #2b2438;
+  --button-secondary-bg-hover: #352d44;
+  --button-secondary-text: #e4dcf0;
+
+  --fb-surface-peek: rgb(21 18 28 / 0.24);
+  --fb-surface-glass: rgb(32 26 42 / 0.60);
+  --fb-surface-pin: rgb(32 26 42 / 0.96);
+  --fb-surface-pin-a0: rgb(32 26 42 / 0);
+  --fb-surface-pin-72: rgb(32 26 42 / 0.72);
+  --fb-surface-pin-95: rgb(32 26 42 / 0.95);
+  --fb-glass-border: rgb(255 255 255 / 0.16);
+  --fb-glass-border-soft: rgb(255 255 255 / 0.12);
+  --fb-shadow-strong: rgb(0 0 0 / 0.38);
+  --fb-shadow-soft: rgb(0 0 0 / 0.22);
+  --fb-shadow-preview: rgb(0 0 0 / 0.55);
+  --fb-core-shadow: rgb(0 0 0 / 0.32);
+  --fb-inset-shadow: rgb(0 0 0 / 0.16);
+  --fb-control-hover: rgb(255 255 255 / 0.08);
+  --fb-line-input: rgb(228 220 240 / 0.08);
+  --fb-line-thumb: rgb(228 220 240 / 0.16);
+  --fb-drag-handle: rgb(228 220 240 / 0.20);
+  --fb-scroll-thumb: rgb(155 145 173 / 0.56);
+
+  --line: rgb(228 220 240 / 0.10);
+  --line-strong: rgb(228 220 240 / 0.18);
+  --line-subtle: rgb(228 220 240 / 0.06);
+
+  --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.12);
+  --shadow-sm: 0 2px 8px rgb(0 0 0 / 0.18);
+  --shadow-md: 0 8px 24px rgb(0 0 0 / 0.28);
+  --shadow-lg: 0 16px 40px rgb(0 0 0 / 0.35);
+  --shadow-xl: 0 24px 48px rgb(0 0 0 / 0.42);
+
+  --focus-border: var(--accent);
+  --toggle-thumb: #e4dcf0;
+  --toggle-off-bg: rgb(228 220 240 / 0.18);
+}
+
 /* Viewport-locked app: prevent document-level scrolling entirely.
    All scrolling is handled by inner containers (MessageList, panels, etc.). */
 html,
@@ -659,6 +1001,36 @@ body {
   background:
     radial-gradient(1200px 700px at 82% -10%, #213321 0%, rgb(33 51 33 / 0) 55%),
     radial-gradient(900px 600px at -10% 110%, #17302d 0%, rgb(23 48 45 / 0) 55%),
+    var(--paper);
+}
+
+[data-color-theme="mauve"]:not(.dark) body {
+  background:
+    radial-gradient(1200px 700px at 82% -10%, #ead8e8 0%, rgb(234 216 232 / 0) 55%),
+    radial-gradient(900px 600px at -10% 110%, #d9d6ec 0%, rgb(217 214 236 / 0) 55%),
+    linear-gradient(120deg, rgb(255 255 255 / 0.48), rgb(255 255 255 / 0)),
+    var(--paper);
+}
+
+.dark[data-color-theme="mauve"] body {
+  background:
+    radial-gradient(1200px 700px at 82% -10%, #342034 0%, rgb(52 32 52 / 0) 55%),
+    radial-gradient(900px 600px at -10% 110%, #2a2540 0%, rgb(42 37 64 / 0) 55%),
+    var(--paper);
+}
+
+[data-color-theme="wisteria"]:not(.dark) body {
+  background:
+    radial-gradient(1200px 700px at 82% -10%, #e3d9f5 0%, rgb(227 217 245 / 0) 55%),
+    radial-gradient(900px 600px at -10% 110%, #d8e0f2 0%, rgb(216 224 242 / 0) 55%),
+    linear-gradient(120deg, rgb(255 255 255 / 0.48), rgb(255 255 255 / 0)),
+    var(--paper);
+}
+
+.dark[data-color-theme="wisteria"] body {
+  background:
+    radial-gradient(1200px 700px at 82% -10%, #2c2340 0%, rgb(44 35 64 / 0) 55%),
+    radial-gradient(900px 600px at -10% 110%, #202c42 0%, rgb(32 44 66 / 0) 55%),
     var(--paper);
 }
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -439,6 +439,177 @@
   color-scheme: dark;
 }
 
+/* ============================================================
+   Color Theme — "Sage" (鼠尾草)
+   Keeps light/dark brightness semantics while swapping the app palette.
+   ============================================================ */
+[data-color-theme="sage"]:not(.dark) {
+  --ink: #17221b;
+  --ink-secondary: #27352b;
+  --ink-muted: #657367;
+  --ink-subtle: #95a091;
+  --ink-faint: #b6beb0;
+
+  --paper: #f3f7ef;
+  --paper-elevated: #fbfff8;
+  --message-user-bg: #fdfff9;
+  --paper-inset: #dce8d6;
+  --paper-a0: rgb(243 247 239 / 0);
+  --paper-elevated-a0: rgb(251 255 248 / 0);
+  --message-user-bg-a0: rgb(253 255 249 / 0);
+  --paper-inset-a0: rgb(220 232 214 / 0);
+  --hover-bg: rgb(95 143 104 / 0.09);
+
+  --accent: #5f8f68;
+  --accent-warm: #5f8f68;
+  --accent-warm-hover: #6fa979;
+  --accent-warm-subtle: rgb(95 143 104 / 0.10);
+  --accent-warm-muted: rgb(95 143 104 / 0.18);
+  --accent-warm-subtle-a0: rgb(95 143 104 / 0);
+  --accent-cool: #4f8278;
+  --accent-cool-hover: #60998e;
+
+  --heartbeat: #bd5f58;
+  --heartbeat-bg: rgb(189 95 88 / 0.10);
+  --heartbeat-border: rgb(189 95 88 / 0.20);
+
+  --success: #3f8a5b;
+  --success-bg: #dcecdf;
+  --error: #c84545;
+  --error-bg: #f5dede;
+  --error-hover: #ad3737;
+  --error-subtle: rgb(200 69 69 / 0.08);
+  --warning: #a66a14;
+  --warning-bg: #f2e9c8;
+  --info: #487b86;
+  --info-bg: #dce9ea;
+
+  --button-primary-bg: #5f8f68;
+  --button-primary-bg-hover: #527e5a;
+  --button-primary-text: #ffffff;
+  --button-dark-bg: #17221b;
+  --button-dark-bg-hover: #2d3c32;
+  --button-secondary-bg: #dce8d6;
+  --button-secondary-bg-hover: #cfddc8;
+  --button-secondary-text: #17221b;
+
+  --fb-surface-peek: rgb(247 252 243 / 0.16);
+  --fb-surface-glass: rgb(247 252 243 / 0.58);
+  --fb-surface-pin: rgb(247 252 243 / 0.96);
+  --fb-surface-pin-a0: rgb(247 252 243 / 0);
+  --fb-surface-pin-72: rgb(247 252 243 / 0.72);
+  --fb-surface-pin-95: rgb(247 252 243 / 0.95);
+  --fb-glass-border: rgb(255 255 255 / 0.64);
+  --fb-glass-border-soft: rgb(255 255 255 / 0.50);
+  --fb-shadow-strong: rgb(23 34 27 / 0.26);
+  --fb-shadow-soft: rgb(23 34 27 / 0.12);
+  --fb-shadow-preview: rgb(23 34 27 / 0.42);
+  --fb-core-shadow: rgb(23 34 27 / 0.22);
+  --fb-inset-shadow: rgb(23 34 27 / 0.08);
+  --fb-control-hover: rgb(23 34 27 / 0.06);
+  --fb-line-input: rgb(23 34 27 / 0.07);
+  --fb-line-thumb: rgb(23 34 27 / 0.12);
+  --fb-drag-handle: rgb(23 34 27 / 0.18);
+  --fb-scroll-thumb: rgb(149 160 145 / 0.52);
+
+  --line: rgb(23 34 27 / 0.10);
+  --line-strong: rgb(23 34 27 / 0.18);
+  --line-subtle: rgb(23 34 27 / 0.06);
+
+  --shadow-xs: 0 1px 2px rgb(23 34 27 / 0.05);
+  --shadow-sm: 0 2px 8px rgb(23 34 27 / 0.08);
+  --shadow-md: 0 8px 24px rgb(23 34 27 / 0.12);
+  --shadow-lg: 0 16px 40px rgb(23 34 27 / 0.16);
+  --shadow-xl: 0 24px 48px rgb(23 34 27 / 0.20);
+
+  --focus-border: #17221b;
+  --toggle-off-bg: rgb(23 34 27 / 0.18);
+}
+
+.dark[data-color-theme="sage"] {
+  --ink: #dce8d7;
+  --ink-secondary: #c6d3c2;
+  --ink-muted: #94a28f;
+  --ink-subtle: #64715f;
+  --ink-faint: #475142;
+
+  --paper: #121912;
+  --paper-elevated: #1a241a;
+  --message-user-bg: #202c20;
+  --paper-inset: #0d120d;
+  --paper-a0: rgb(18 25 18 / 0);
+  --paper-elevated-a0: rgb(26 36 26 / 0);
+  --message-user-bg-a0: rgb(32 44 32 / 0);
+  --paper-inset-a0: rgb(13 18 13 / 0);
+  --hover-bg: rgb(127 177 132 / 0.13);
+
+  --accent: #7fb184;
+  --accent-warm: #7fb184;
+  --accent-warm-hover: #92c797;
+  --accent-warm-subtle: rgb(127 177 132 / 0.13);
+  --accent-warm-muted: rgb(127 177 132 / 0.22);
+  --accent-warm-subtle-a0: rgb(127 177 132 / 0);
+  --accent-cool: #6cb3a5;
+  --accent-cool-hover: #7fcabc;
+
+  --heartbeat: #d4706a;
+  --heartbeat-bg: rgb(212 112 106 / 0.13);
+  --heartbeat-border: rgb(212 112 106 / 0.23);
+
+  --success: #7fb184;
+  --success-bg: rgb(127 177 132 / 0.16);
+  --error: #ef6b66;
+  --error-bg: rgb(239 107 102 / 0.16);
+  --error-hover: #db5b55;
+  --error-subtle: rgb(239 107 102 / 0.13);
+  --warning: #d6a84c;
+  --warning-bg: rgb(214 168 76 / 0.16);
+  --info: #77aeb8;
+  --info-bg: rgb(119 174 184 / 0.16);
+
+  --button-primary-bg: #7fb184;
+  --button-primary-bg-hover: #6da073;
+  --button-primary-text: #0f150f;
+  --button-dark-bg: #3a4738;
+  --button-dark-bg-hover: #4a5a47;
+  --button-secondary-bg: #243024;
+  --button-secondary-bg-hover: #2d3a2d;
+  --button-secondary-text: #dce8d7;
+
+  --fb-surface-peek: rgb(18 25 18 / 0.24);
+  --fb-surface-glass: rgb(26 36 26 / 0.60);
+  --fb-surface-pin: rgb(26 36 26 / 0.96);
+  --fb-surface-pin-a0: rgb(26 36 26 / 0);
+  --fb-surface-pin-72: rgb(26 36 26 / 0.72);
+  --fb-surface-pin-95: rgb(26 36 26 / 0.95);
+  --fb-glass-border: rgb(255 255 255 / 0.16);
+  --fb-glass-border-soft: rgb(255 255 255 / 0.12);
+  --fb-shadow-strong: rgb(0 0 0 / 0.38);
+  --fb-shadow-soft: rgb(0 0 0 / 0.22);
+  --fb-shadow-preview: rgb(0 0 0 / 0.55);
+  --fb-core-shadow: rgb(0 0 0 / 0.32);
+  --fb-inset-shadow: rgb(0 0 0 / 0.16);
+  --fb-control-hover: rgb(255 255 255 / 0.08);
+  --fb-line-input: rgb(220 232 215 / 0.08);
+  --fb-line-thumb: rgb(220 232 215 / 0.16);
+  --fb-drag-handle: rgb(220 232 215 / 0.20);
+  --fb-scroll-thumb: rgb(148 162 143 / 0.56);
+
+  --line: rgb(220 232 215 / 0.10);
+  --line-strong: rgb(220 232 215 / 0.18);
+  --line-subtle: rgb(220 232 215 / 0.06);
+
+  --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.12);
+  --shadow-sm: 0 2px 8px rgb(0 0 0 / 0.18);
+  --shadow-md: 0 8px 24px rgb(0 0 0 / 0.28);
+  --shadow-lg: 0 16px 40px rgb(0 0 0 / 0.35);
+  --shadow-xl: 0 24px 48px rgb(0 0 0 / 0.42);
+
+  --focus-border: var(--accent);
+  --toggle-thumb: #dce8d7;
+  --toggle-off-bg: rgb(220 232 215 / 0.18);
+}
+
 /* Viewport-locked app: prevent document-level scrolling entirely.
    All scrolling is handled by inner containers (MessageList, panels, etc.). */
 html,
@@ -473,6 +644,21 @@ body {
     /* #333: 同色 0-alpha 端点，禁用 `transparent` 关键字（见 paper token 区注释） */
     radial-gradient(1200px 700px at 82% -10%, #2a2018 0%, rgb(42 32 24 / 0) 55%),
     radial-gradient(900px 600px at -10% 110%, #1a2420 0%, rgb(26 36 32 / 0) 55%),
+    var(--paper);
+}
+
+[data-color-theme="sage"]:not(.dark) body {
+  background:
+    radial-gradient(1200px 700px at 82% -10%, #d5e8d0 0%, rgb(213 232 208 / 0) 55%),
+    radial-gradient(900px 600px at -10% 110%, #cfe4de 0%, rgb(207 228 222 / 0) 55%),
+    linear-gradient(120deg, rgb(255 255 255 / 0.48), rgb(255 255 255 / 0)),
+    var(--paper);
+}
+
+.dark[data-color-theme="sage"] body {
+  background:
+    radial-gradient(1200px 700px at 82% -10%, #213321 0%, rgb(33 51 33 / 0) 55%),
+    radial-gradient(900px 600px at -10% 110%, #17302d 0%, rgb(23 48 45 / 0) 55%),
     var(--paper);
 }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -11,7 +11,7 @@
         var t = localStorage.getItem('theme') || 'system';
         if (t === 'dark' || (t === 'system' && matchMedia('(prefers-color-scheme:dark)').matches))
           document.documentElement.classList.add('dark');
-        var c = localStorage.getItem('colorTheme') || 'warm';
+        var c = localStorage.getItem('colorTheme') || 'sage';
         if (c === 'sage')
           document.documentElement.setAttribute('data-color-theme', 'sage');
       } catch(e) {}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -4,13 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MyAgents</title>
-    <!-- Prevent FOUC: apply dark class before React renders.
-         useThemeEffect mirrors config.theme to localStorage('theme'). -->
+    <!-- Prevent FOUC: apply theme markers before React renders.
+         useThemeEffect mirrors config.theme / config.colorTheme to localStorage. -->
     <script>
       try {
         var t = localStorage.getItem('theme') || 'system';
         if (t === 'dark' || (t === 'system' && matchMedia('(prefers-color-scheme:dark)').matches))
           document.documentElement.classList.add('dark');
+        var c = localStorage.getItem('colorTheme') || 'warm';
+        if (c === 'sage')
+          document.documentElement.setAttribute('data-color-theme', 'sage');
       } catch(e) {}
     </script>
   </head>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -12,8 +12,8 @@
         if (t === 'dark' || (t === 'system' && matchMedia('(prefers-color-scheme:dark)').matches))
           document.documentElement.classList.add('dark');
         var c = localStorage.getItem('colorTheme') || 'sage';
-        if (c === 'sage')
-          document.documentElement.setAttribute('data-color-theme', 'sage');
+        if (c === 'sage' || c === 'mauve' || c === 'wisteria')
+          document.documentElement.setAttribute('data-color-theme', c);
       } catch(e) {}
     </script>
   </head>

--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -44,7 +44,10 @@ import {
     normalizeChatQueueResponseMode,
     getManagedCodexProviderReadiness,
     isManagedCodexProviderGateEnabled,
+    COLOR_THEMES,
+    normalizeColorTheme,
     type ChatQueueResponseMode,
+    type ColorTheme,
     type ProxyProtocol,
 } from '@/config/types';
 import {
@@ -266,6 +269,7 @@ export default function Settings({ initialSection, initialMcpId, initialOfficial
         { value: 'zh-CN', label: tCommon('language.zhCN') },
         { value: 'en-US', label: tCommon('language.enUS') },
     ], [tCommon]);
+    const selectedColorTheme = normalizeColorTheme(config.colorTheme);
     const [claudeTranscriptCleanupDaysDraft, setClaudeTranscriptCleanupDaysDraft] = useState(
         String(DEFAULT_CLAUDE_TRANSCRIPT_CLEANUP_PERIOD_DAYS),
     );
@@ -4082,6 +4086,29 @@ export default function Settings({ initialSection, initialMcpId, initialOfficial
                                                 }`}
                                             >
                                                 {tSettings(`general.theme.${mode}`)}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+
+                                <div className="mt-4 flex items-center justify-between gap-4">
+                                    <div className="flex-1 pr-4">
+                                        <p className="text-sm font-medium text-[var(--ink)]">{tSettings('general.colorThemeTitle')}</p>
+                                        <p className="mt-0.5 text-xs text-[var(--ink-muted)]">{tSettings('general.colorThemeDescription')}</p>
+                                    </div>
+                                    <div className="flex shrink-0 gap-0.5 rounded-full bg-[var(--paper-inset)] p-0.5">
+                                        {COLOR_THEMES.map((colorTheme) => (
+                                            <button
+                                                key={colorTheme}
+                                                type="button"
+                                                onClick={() => updateConfig({ colorTheme: colorTheme as ColorTheme })}
+                                                className={`rounded-full px-3 py-1 text-xs font-medium transition-all ${
+                                                    selectedColorTheme === colorTheme
+                                                        ? 'bg-[var(--paper-elevated)] text-[var(--ink)] shadow-sm'
+                                                        : 'text-[var(--ink-muted)] hover:text-[var(--ink-secondary)]'
+                                                }`}
+                                            >
+                                                {tSettings(`general.colorTheme.${colorTheme}`)}
                                             </button>
                                         ))}
                                     </div>

--- a/src/shared/config-types.test.ts
+++ b/src/shared/config-types.test.ts
@@ -190,10 +190,11 @@ describe('normalizeChatQueueResponseMode', () => {
 });
 
 describe('normalizeColorTheme', () => {
-  it('keeps sage and falls back to warm for missing or unknown values', () => {
+  it('keeps explicit color themes and falls back to sage for missing or unknown values', () => {
     expect(normalizeColorTheme('sage')).toBe('sage');
-    expect(normalizeColorTheme(undefined)).toBe('warm');
-    expect(normalizeColorTheme('forest')).toBe('warm');
+    expect(normalizeColorTheme('warm')).toBe('warm');
+    expect(normalizeColorTheme(undefined)).toBe('sage');
+    expect(normalizeColorTheme('forest')).toBe('sage');
   });
 });
 

--- a/src/shared/config-types.test.ts
+++ b/src/shared/config-types.test.ts
@@ -18,6 +18,7 @@ import {
   mergePresetModelWithCustomEntry,
   normalizeChatQueueResponseMode,
   normalizeClaudeTranscriptCleanupPeriodDays,
+  normalizeColorTheme,
   normalizeProviderOrder,
   splitProviderModelInput,
   withManagedCodexRuntimeModels,
@@ -185,6 +186,14 @@ describe('normalizeChatQueueResponseMode', () => {
     expect(normalizeChatQueueResponseMode('realtime')).toBe('realtime');
     expect(normalizeChatQueueResponseMode('turn')).toBe('turn');
     expect(normalizeChatQueueResponseMode('invalid')).toBe('realtime');
+  });
+});
+
+describe('normalizeColorTheme', () => {
+  it('keeps sage and falls back to warm for missing or unknown values', () => {
+    expect(normalizeColorTheme('sage')).toBe('sage');
+    expect(normalizeColorTheme(undefined)).toBe('warm');
+    expect(normalizeColorTheme('forest')).toBe('warm');
   });
 });
 

--- a/src/shared/config-types.test.ts
+++ b/src/shared/config-types.test.ts
@@ -193,6 +193,8 @@ describe('normalizeColorTheme', () => {
   it('keeps explicit color themes and falls back to sage for missing or unknown values', () => {
     expect(normalizeColorTheme('sage')).toBe('sage');
     expect(normalizeColorTheme('warm')).toBe('warm');
+    expect(normalizeColorTheme('mauve')).toBe('mauve');
+    expect(normalizeColorTheme('wisteria')).toBe('wisteria');
     expect(normalizeColorTheme(undefined)).toBe('sage');
     expect(normalizeColorTheme('forest')).toBe('sage');
   });

--- a/src/shared/config-types.ts
+++ b/src/shared/config-types.ts
@@ -20,6 +20,13 @@ export type PermissionMode = 'auto' | 'plan' | 'fullAgency';
  */
 export type BackgroundAgentPermissionMode = 'inherit' | 'fullAgency';
 
+export const COLOR_THEMES = ['warm', 'sage'] as const;
+export type ColorTheme = typeof COLOR_THEMES[number];
+
+export function normalizeColorTheme(value: unknown): ColorTheme {
+  return value === 'sage' ? 'sage' : 'warm';
+}
+
 /**
  * Permission mode display configuration
  * Based on PRD 0.0.17 mode definitions
@@ -694,6 +701,7 @@ export interface AppConfig {
   backgroundAgentPermissionMode?: BackgroundAgentPermissionMode;
   // UI preferences
   theme: 'light' | 'dark' | 'system';
+  colorTheme?: ColorTheme;
   /** Product UI language. Existing pre-i18n configs missing this field migrate
    *  to `zh-CN`; new installs default to `system`. */
   uiLanguage?: UiLanguage;
@@ -1783,6 +1791,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   defaultPermissionMode: 'auto',
   backgroundAgentPermissionMode: 'inherit', // background agents inherit granted perms; nothing wider (#264)
   theme: 'system',
+  colorTheme: 'warm',
   uiLanguage: 'system',
   minimizeToTray: true,   // 默认开启最小化到托盘
   forceWakeLock: false,   // 默认关闭常开阻睡（智能模式仍在跑，覆盖 AI 工作期间）

--- a/src/shared/config-types.ts
+++ b/src/shared/config-types.ts
@@ -20,12 +20,12 @@ export type PermissionMode = 'auto' | 'plan' | 'fullAgency';
  */
 export type BackgroundAgentPermissionMode = 'inherit' | 'fullAgency';
 
-export const COLOR_THEMES = ['warm', 'sage'] as const;
+export const COLOR_THEMES = ['warm', 'sage', 'mauve', 'wisteria'] as const;
 export type ColorTheme = typeof COLOR_THEMES[number];
 export const DEFAULT_COLOR_THEME: ColorTheme = 'sage';
 
 export function normalizeColorTheme(value: unknown): ColorTheme {
-  if (value === 'warm' || value === 'sage') return value;
+  if (COLOR_THEMES.includes(value as ColorTheme)) return value as ColorTheme;
   return DEFAULT_COLOR_THEME;
 }
 

--- a/src/shared/config-types.ts
+++ b/src/shared/config-types.ts
@@ -22,9 +22,11 @@ export type BackgroundAgentPermissionMode = 'inherit' | 'fullAgency';
 
 export const COLOR_THEMES = ['warm', 'sage'] as const;
 export type ColorTheme = typeof COLOR_THEMES[number];
+export const DEFAULT_COLOR_THEME: ColorTheme = 'sage';
 
 export function normalizeColorTheme(value: unknown): ColorTheme {
-  return value === 'sage' ? 'sage' : 'warm';
+  if (value === 'warm' || value === 'sage') return value;
+  return DEFAULT_COLOR_THEME;
 }
 
 /**
@@ -1791,7 +1793,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   defaultPermissionMode: 'auto',
   backgroundAgentPermissionMode: 'inherit', // background agents inherit granted perms; nothing wider (#264)
   theme: 'system',
-  colorTheme: 'warm',
+  colorTheme: DEFAULT_COLOR_THEME,
   uiLanguage: 'system',
   minimizeToTray: true,   // 默认开启最小化到托盘
   forceWakeLock: false,   // 默认关闭常开阻睡（智能模式仍在跑，覆盖 AI 工作期间）


### PR DESCRIPTION
## Summary
- Add an app-wide sage color theme backed by shared config
- Add Settings controls for switching between Warm Paper and Sage palettes
- Default new/missing color theme config to Sage while keeping light/dark/system brightness separate

## Tests
- npm run test:unit -- config-types
- npm run typecheck