### PR TITLE
fix(windows): repair native inference setup

### DIFF
--- a/scripts/prepare-speech-inference.mjs
+++ b/scripts/prepare-speech-inference.mjs
@@ -28,7 +28,10 @@ import {
   validatePreparedSpeechBundle,
   validateSpeechBuildLock,
 } from './speech-inference-resource-cache.mjs';
-import { extractSherpaBuildSource } from './sherpa-source-extraction.mjs';
+import {
+  extractSherpaBuildSource,
+  patchSherpaWindowsOnnxRuntimeImport,
+} from './sherpa-source-extraction.mjs';
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const appVersion = JSON.parse(
@@ -476,12 +479,15 @@ export async function prepareSpeechInference(options, documentResult) {
   if (existsSync(preparedRoot)) {
     rmSync(preparedRoot, { recursive: true, force: true });
   }
-  const workParent = join(cacheRoot, 'speech-work');
+  // MSBuild FileTracker still creates MAX_PATH-sensitive nested tlog paths.
+  // Keep transient build segments short while the final cache and projection
+  // retain their descriptive, target-scoped names.
+  const workParent = join(cacheRoot, 'w');
   mkdirSync(workParent, { recursive: true });
-  const workRoot = mkdtempSync(join(workParent, `${target}-`));
-  const stageRoot = join(workRoot, 'v1');
-  const extractRoot = join(workRoot, 'extract');
-  const buildRoot = join(workRoot, 'build');
+  const workRoot = mkdtempSync(join(workParent, 's-'));
+  const stageRoot = join(workRoot, 'v');
+  const extractRoot = join(workRoot, 'x');
+  const buildRoot = join(workRoot, 'b');
   mkdirSync(join(stageRoot, 'native'), { recursive: true });
   mkdirSync(join(stageRoot, 'legal'), { recursive: true });
   mkdirSync(extractRoot, { recursive: true });
@@ -492,19 +498,22 @@ export async function prepareSpeechInference(options, documentResult) {
       speechLock.source,
       speechLock.source.archiveName,
     );
-    const sourceExtract = join(extractRoot, 'sherpa-source');
+    const sourceExtract = join(extractRoot, 's');
     mkdirSync(sourceExtract, { recursive: true });
     const sherpaSource = extractSherpaBuildSource({
       archive: sourceArchive,
       destination: sourceExtract,
       archiveRoot: speechLock.source.archiveRoot,
     });
+    if (targetLock.platform === 'windows') {
+      patchSherpaWindowsOnnxRuntimeImport(sherpaSource);
+    }
     for (const dependency of speechLock.dependencies) {
       const archive = await acquire(dependency, dependency.archiveName);
       copyFileSync(archive, join(sherpaSource, dependency.archiveName));
     }
 
-    const ortBuildRoot = join(workRoot, 'onnxruntime');
+    const ortBuildRoot = join(workRoot, 'o');
     const ortLibraryRoot = join(ortBuildRoot, 'lib');
     mkdirSync(ortLibraryRoot, { recursive: true });
     const runtimeBuildName =
@@ -560,7 +569,7 @@ export async function prepareSpeechInference(options, documentResult) {
       );
     }
 
-    const sherpaBuild = join(buildRoot, 'sherpa');
+    const sherpaBuild = join(buildRoot, 's');
     execFileSync(
       'cmake',
       [
@@ -620,8 +629,16 @@ export async function prepareSpeechInference(options, documentResult) {
         `${targetLock.platform === 'windows' ? '' : 'lib'}sherpa-onnx-c-api${sharedLibraryExtension}`,
       'sherpa-onnx C API shared library',
     );
+    const sherpaLinkLibrary =
+      targetLock.platform === 'windows'
+        ? findOne(
+            sherpaBuild,
+            (path) => basename(path) === 'sherpa-onnx-c-api.lib',
+            'sherpa-onnx C API import library',
+          )
+        : sherpaLibrary;
 
-    const adapterBuild = join(buildRoot, 'adapter');
+    const adapterBuild = join(buildRoot, 'a');
     const hclustIncludeRoot = join(sherpaBuild, '_deps', 'hclust_cpp-src');
     if (!existsSync(join(hclustIncludeRoot, 'fastcluster-all-in-one.h'))) {
       throw new Error(
@@ -637,7 +654,7 @@ export async function prepareSpeechInference(options, documentResult) {
         adapterBuild,
         '-DCMAKE_BUILD_TYPE=Release',
         `-DMYAGENTS_SHERPA_INCLUDE_DIR=${sherpaSource}`,
-        `-DMYAGENTS_SHERPA_LIBRARY_DIR=${dirname(sherpaLibrary)}`,
+        `-DMYAGENTS_SHERPA_LIBRARY=${sherpaLinkLibrary}`,
         `-DMYAGENTS_HCLUST_INCLUDE_DIR=${hclustIncludeRoot}`,
         ...configurePlatformArgs(),
       ],

--- a/scripts/sherpa-source-extraction.mjs
+++ b/scripts/sherpa-source-extraction.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { lstatSync, mkdirSync } from 'node:fs';
+import { lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 export const SHERPA_BUILD_MEMBERS = Object.freeze([
@@ -9,6 +9,26 @@ export const SHERPA_BUILD_MEMBERS = Object.freeze([
   'sherpa-onnx',
 ]);
 
+const WINDOWS_ORT_IMPORT_BROKEN = `    elseif(WIN32)
+      if(SHERPA_ONNX_ENABLE_GPU)
+        set(location_onnxruntime_lib $ENV{SHERPA_ONNXRUNTIME_LIB_DIR}/onnxruntime.dll)
+        set(location_onnxruntime_lib2 $ENV{SHERPA_ONNXRUNTIME_LIB_DIR}/onnxruntime.lib)
+      else()
+        set(location_onnxruntime_lib $ENV{SHERPA_ONNXRUNTIME_LIB_DIR}/onnxruntime.lib)
+        if(SHERPA_ONNX_ENABLE_DIRECTML)
+          include(onnxruntime-win-x64-directml)
+        endif()
+      endif()
+`;
+
+const WINDOWS_ORT_IMPORT_FIXED = `    elseif(WIN32)
+      set(location_onnxruntime_lib $ENV{SHERPA_ONNXRUNTIME_LIB_DIR}/onnxruntime.dll)
+      set(location_onnxruntime_lib2 $ENV{SHERPA_ONNXRUNTIME_LIB_DIR}/onnxruntime.lib)
+      if(SHERPA_ONNX_ENABLE_DIRECTML)
+        include(onnxruntime-win-x64-directml)
+      endif()
+`;
+
 function requireEntry(path, kind) {
   const metadata = lstatSync(path);
   const valid =
@@ -17,6 +37,30 @@ function requireEntry(path, kind) {
   if (!valid) {
     throw new Error(`Sherpa build source ${kind} is unavailable: ${path}`);
   }
+}
+
+export function patchSherpaWindowsOnnxRuntimeImport(sourceRoot) {
+  const cmakePath = join(sourceRoot, 'cmake', 'onnxruntime.cmake');
+  requireEntry(cmakePath, 'file');
+  const source = readFileSync(cmakePath, 'utf8');
+  if (source.includes(WINDOWS_ORT_IMPORT_FIXED)) {
+    return false;
+  }
+  const firstMatch = source.indexOf(WINDOWS_ORT_IMPORT_BROKEN);
+  if (
+    firstMatch < 0 ||
+    source.indexOf(WINDOWS_ORT_IMPORT_BROKEN, firstMatch + 1) >= 0
+  ) {
+    throw new Error(
+      'Locked Sherpa ONNX Runtime CMake no longer matches the expected Windows CPU import block',
+    );
+  }
+  writeFileSync(
+    cmakePath,
+    source.replace(WINDOWS_ORT_IMPORT_BROKEN, WINDOWS_ORT_IMPORT_FIXED),
+    'utf8',
+  );
+  return true;
 }
 
 export function extractSherpaBuildSource({

--- a/scripts/sherpa-source-extraction.test.mjs
+++ b/scripts/sherpa-source-extraction.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import {
   existsSync,
   mkdtempSync,
+  mkdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -10,7 +11,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { extractSherpaBuildSource } from './sherpa-source-extraction.mjs';
+import {
+  extractSherpaBuildSource,
+  patchSherpaWindowsOnnxRuntimeImport,
+} from './sherpa-source-extraction.mjs';
 
 // A tiny tar.gz with the required build tree plus an unrelated symlink. The
 // extractor must never ask the host tar to materialize that symlink on Windows.
@@ -57,6 +61,65 @@ test('rejects an archive root that could escape the extraction destination', () 
           archiveRoot: '../outside',
         }),
       /invalid archive root/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('patches the locked Sherpa Windows CPU import to use the DLL and import library pair', () => {
+  const root = mkdtempSync(join(tmpdir(), 'myagents-sherpa-ort-import-'));
+  const cmakeRoot = join(root, 'cmake');
+  const cmakePath = join(cmakeRoot, 'onnxruntime.cmake');
+  mkdirSync(cmakeRoot, { recursive: true });
+  writeFileSync(
+    cmakePath,
+    `before\n    elseif(WIN32)
+      if(SHERPA_ONNX_ENABLE_GPU)
+        set(location_onnxruntime_lib $ENV{SHERPA_ONNXRUNTIME_LIB_DIR}/onnxruntime.dll)
+        set(location_onnxruntime_lib2 $ENV{SHERPA_ONNXRUNTIME_LIB_DIR}/onnxruntime.lib)
+      else()
+        set(location_onnxruntime_lib $ENV{SHERPA_ONNXRUNTIME_LIB_DIR}/onnxruntime.lib)
+        if(SHERPA_ONNX_ENABLE_DIRECTML)
+          include(onnxruntime-win-x64-directml)
+        endif()
+      endif()
+after\n`,
+  );
+
+  try {
+    assert.equal(patchSherpaWindowsOnnxRuntimeImport(root), true);
+    const patched = readFileSync(cmakePath, 'utf8');
+    assert.match(
+      patched,
+      /set\(location_onnxruntime_lib \$ENV\{SHERPA_ONNXRUNTIME_LIB_DIR\}\/onnxruntime\.dll\)/,
+    );
+    assert.match(
+      patched,
+      /set\(location_onnxruntime_lib2 \$ENV\{SHERPA_ONNXRUNTIME_LIB_DIR\}\/onnxruntime\.lib\)/,
+    );
+    assert.doesNotMatch(patched, /if\(SHERPA_ONNX_ENABLE_GPU\)/);
+    assert.equal(patchSherpaWindowsOnnxRuntimeImport(root), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects Sherpa CMake drift instead of applying an ambiguous patch', () => {
+  const root = mkdtempSync(join(tmpdir(), 'myagents-sherpa-ort-drift-'));
+  const cmakeRoot = join(root, 'cmake');
+  const cmakePath = join(cmakeRoot, 'onnxruntime.cmake');
+  mkdirSync(cmakeRoot, { recursive: true });
+  writeFileSync(cmakePath, 'unexpected upstream content\n');
+
+  try {
+    assert.throws(
+      () => patchSherpaWindowsOnnxRuntimeImport(root),
+      /no longer matches the expected Windows CPU import block/,
+    );
+    assert.equal(
+      readFileSync(cmakePath, 'utf8'),
+      'unexpected upstream content\n',
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/src-tauri/media-worker/native/CMakeLists.txt
+++ b/src-tauri/media-worker/native/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.28)
 project(myagents_speech_adapter LANGUAGES CXX)
 
-foreach(required IN ITEMS MYAGENTS_SHERPA_INCLUDE_DIR MYAGENTS_SHERPA_LIBRARY_DIR MYAGENTS_HCLUST_INCLUDE_DIR)
+foreach(required IN ITEMS MYAGENTS_SHERPA_INCLUDE_DIR MYAGENTS_SHERPA_LIBRARY MYAGENTS_HCLUST_INCLUDE_DIR)
   if(NOT DEFINED ${required} OR "${${required}}" STREQUAL "")
     message(FATAL_ERROR "${required} is required")
   endif()
@@ -21,11 +21,10 @@ target_include_directories(
   myagents-speech-adapter
   SYSTEM PRIVATE "${MYAGENTS_HCLUST_INCLUDE_DIR}"
 )
-target_link_directories(
+target_link_libraries(
   myagents-speech-adapter
-  PRIVATE "${MYAGENTS_SHERPA_LIBRARY_DIR}"
+  PRIVATE "${MYAGENTS_SHERPA_LIBRARY}"
 )
-target_link_libraries(myagents-speech-adapter PRIVATE sherpa-onnx-c-api)
 set_target_properties(
   myagents-speech-adapter
   PROPERTIES
@@ -49,7 +48,7 @@ elseif(UNIX)
 endif()
 
 if(MSVC)
-  target_compile_options(myagents-speech-adapter PRIVATE /W4 /WX /EHsc)
+  target_compile_options(myagents-speech-adapter PRIVATE /W4 /WX /EHsc /utf-8)
 else()
   target_compile_options(
     myagents-speech-adapter


### PR DESCRIPTION
## Summary\n- shorten transient Windows native build paths\n- fix locked Sherpa ONNX Runtime DLL/import-library wiring\n- link the speech adapter to the exact discovered import library\n\n## Validation\n- includes deterministic source-patch regression coverage\n- requires the repository Test workflow on this exact SHA before merge