### PR TITLE
fix: 汇总 Windows 构建、媒体生命周期与任务栏图标修复

### DIFF
--- a/scripts/build-resource-staging.test.mjs
+++ b/scripts/build-resource-staging.test.mjs
@@ -691,7 +691,16 @@ test('speech inference builds a signed exact native inventory around the shared 
   assert.match(speechResourceScript, /SHERPA_ONNX_BUILD_C_API_EXAMPLES=OFF/);
   assert.match(
     speechResourceScript,
-    /CMAKE_CXX_FLAGS=-DSHERPA_ONNX_DISABLE_COREML=1/,
+    /CMAKE_CXX_FLAGS_INIT=-DSHERPA_ONNX_DISABLE_COREML=1/,
+  );
+  assert.doesNotMatch(speechResourceScript, /-DCMAKE_CXX_FLAGS=/);
+  assert.match(
+    speechResourceScript,
+    /if \(targetLock\.platform === 'windows'\) \{\s+patchHclustWindowsFenvPragma\(hclustIncludeRoot\);/,
+  );
+  assert.ok(
+    speechResourceScript.indexOf('patchHclustWindowsFenvPragma(hclustIncludeRoot)') <
+      speechResourceScript.indexOf("'--build'"),
   );
   assert.match(speechResourceScript, /--target[\s\S]*sherpa-onnx-c-api/);
   assert.match(speechResourceScript, /signNativeFiles/);

--- a/scripts/prepare-speech-inference.mjs
+++ b/scripts/prepare-speech-inference.mjs
@@ -30,6 +30,7 @@ import {
 } from './speech-inference-resource-cache.mjs';
 import {
   extractSherpaBuildSource,
+  patchHclustWindowsFenvPragma,
   patchSherpaWindowsOnnxRuntimeImport,
 } from './sherpa-source-extraction.mjs';
 
@@ -636,7 +637,9 @@ export async function prepareSpeechInference(options, documentResult) {
         '-B',
         sherpaBuild,
         '-DCMAKE_BUILD_TYPE=Release',
-        '-DCMAKE_CXX_FLAGS=-DSHERPA_ONNX_DISABLE_COREML=1',
+        // Initialize extra flags without replacing CMake's platform defaults
+        // (notably MSVC /EHsc, required by Sherpa and its C++ dependencies).
+        '-DCMAKE_CXX_FLAGS_INIT=-DSHERPA_ONNX_DISABLE_COREML=1',
         '-DBUILD_SHARED_LIBS=ON',
         '-DSHERPA_ONNX_BUILD_C_API_EXAMPLES=OFF',
         '-DSHERPA_ONNX_ENABLE_C_API=ON',
@@ -660,6 +663,12 @@ export async function prepareSpeechInference(options, documentResult) {
         stdio: 'inherit',
       },
     );
+    // FetchContent has materialized hclust during configuration. Patch before
+    // compiling Sherpa; the adapter later consumes this same dependency tree.
+    const hclustIncludeRoot = join(sherpaBuild, '_deps', 'hclust_cpp-src');
+    if (targetLock.platform === 'windows') {
+      patchHclustWindowsFenvPragma(hclustIncludeRoot);
+    }
     execFileSync(
       'cmake',
       [
@@ -697,7 +706,6 @@ export async function prepareSpeechInference(options, documentResult) {
         : sherpaLibrary;
 
     const adapterBuild = join(buildRoot, 'a');
-    const hclustIncludeRoot = join(sherpaBuild, '_deps', 'hclust_cpp-src');
     if (!existsSync(join(hclustIncludeRoot, 'fastcluster-all-in-one.h'))) {
       throw new Error(
         `Locked hclust-cpp headers are unavailable: ${hclustIncludeRoot}`,

--- a/scripts/sherpa-source-extraction.mjs
+++ b/scripts/sherpa-source-extraction.mjs
@@ -63,6 +63,28 @@ export function patchSherpaWindowsOnnxRuntimeImport(sourceRoot) {
   return true;
 }
 
+export function patchHclustWindowsFenvPragma(sourceRoot) {
+  const sourcePath = join(sourceRoot, 'fastcluster_dm.cpp');
+  requireEntry(sourcePath, 'file');
+  const source = readFileSync(sourcePath, 'utf8');
+  const original = '#pragma STDC FENV_ACCESS on';
+  // The locked upstream explicitly allows ignoring this pragma. MSVC already
+  // ignores it with C4068; omit only the unsupported directive, keeping fenv
+  // includes/checks and the directive for other compilers intact.
+  const patched = `#ifndef _MSC_VER\n${original}\n#endif`;
+  if (source.includes(patched)) {
+    return false;
+  }
+  const firstMatch = source.indexOf(original);
+  if (firstMatch < 0 || source.indexOf(original, firstMatch + 1) >= 0) {
+    throw new Error(
+      'Locked hclust source no longer matches the expected FENV_ACCESS pragma',
+    );
+  }
+  writeFileSync(sourcePath, source.replace(original, patched), 'utf8');
+  return true;
+}
+
 export function extractSherpaBuildSource({
   archive,
   destination,

--- a/scripts/sherpa-source-extraction.test.mjs
+++ b/scripts/sherpa-source-extraction.test.mjs
@@ -13,6 +13,7 @@ import test from 'node:test';
 
 import {
   extractSherpaBuildSource,
+  patchHclustWindowsFenvPragma,
   patchSherpaWindowsOnnxRuntimeImport,
 } from './sherpa-source-extraction.mjs';
 
@@ -121,6 +122,43 @@ test('rejects Sherpa CMake drift instead of applying an ambiguous patch', () => 
       readFileSync(cmakePath, 'utf8'),
       'unexpected upstream content\n',
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('guards only the unsupported hclust pragma on MSVC and is idempotent', () => {
+  const root = mkdtempSync(join(tmpdir(), 'myagents-hclust-pragma-'));
+  const sourcePath = join(root, 'fastcluster_dm.cpp');
+  const source = 'before\n#pragma STDC FENV_ACCESS on\n#include <fenv.h>\nafter\n';
+  writeFileSync(sourcePath, source);
+  try {
+    assert.equal(patchHclustWindowsFenvPragma(root), true);
+    const expected =
+      'before\n#ifndef _MSC_VER\n#pragma STDC FENV_ACCESS on\n#endif\n#include <fenv.h>\nafter\n';
+    assert.equal(readFileSync(sourcePath, 'utf8'), expected);
+    assert.equal(patchHclustWindowsFenvPragma(root), false);
+    assert.equal(readFileSync(sourcePath, 'utf8'), expected);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects missing or ambiguous hclust pragmas without changing the source', () => {
+  const root = mkdtempSync(join(tmpdir(), 'myagents-hclust-drift-'));
+  const sourcePath = join(root, 'fastcluster_dm.cpp');
+  try {
+    for (const source of [
+      'unexpected upstream content\n',
+      '#pragma STDC FENV_ACCESS on\n#pragma STDC FENV_ACCESS on\n',
+    ]) {
+      writeFileSync(sourcePath, source);
+      assert.throws(
+        () => patchHclustWindowsFenvPragma(root),
+        /no longer matches the expected FENV_ACCESS pragma/,
+      );
+      assert.equal(readFileSync(sourcePath, 'utf8'), source);
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/specs/guides/windows_build_guide.md
+++ b/specs/guides/windows_build_guide.md
@@ -117,6 +117,8 @@ src-tauri/target/x86_64-pc-windows-msvc/debug/myagents.exe
 
 两条 Windows 构建路径都会在 Tauri snapshot 前调用 `scripts/prepare-native-inference.mjs x86_64-pc-windows-msvc`，统一准备 document/speech capability。Sherpa 的锁定源码包只展开构建所需的根 `CMakeLists.txt`、`LICENSE`、`cmake/` 与 `sherpa-onnx/`；上游仓库其它目录中的 symlink 不会在 Windows 上落盘，不需要启用 Developer Mode、管理员权限或长路径开关。正式安装器验证除既有文档转换外，还必须检查 `speech-inference/v1` 的签名 manifest、media Worker/sherpa native inventory、与 `document-processing/v1` 共享的 ONNX Runtime identity，以及无系统 ORT/ffmpeg/Python 时的 WASAPI microphone/loopback、转录与 Job Object 取消。
 
+Sherpa 的附加宏通过 `CMAKE_CXX_FLAGS_INIT` 传入，不能覆盖 `CMAKE_CXX_FLAGS`，否则会丢失 MSVC 默认的 `/EHsc`，引发标准库 C4530 警告并破坏异常展开语义。Windows 构建还会在 CMake 配置完成、编译开始前，为锁定 hclust 源码的 `STDC FENV_ACCESS` pragma 添加 MSVC 条件保护；MSVC 原本就忽略该指令，保护只消除 C4068，保留浮点环境检查。补丁 helper 和准备脚本都参与构建指纹，修复后旧 speech 缓存不会被复用。
+
 ### build_windows.ps1
 
 **运行方式**：

--- a/specs/tech_docs/chat_scroll_presentation_lifecycle.md
+++ b/specs/tech_docs/chat_scroll_presentation_lifecycle.md
@@ -70,6 +70,8 @@ Chat 底部 query 耗时由 TabProvider 的 `useQueryElapsedClock` 持有，使�
 
 Virtuoso 的 Footer 必须使用模块级稳定组件类型，动态内容通过现有 list context 传入，并与 data 一同遵守 frozen snapshot。`useMemo(() => function Footer(){...}, [动态值])` 仍会在依赖变化时创建新组件类型，重挂载整个 footer，不能作为“稳定 Footer”。
 
+冻结展示 snapshot 不等于暂停组件内部的副作用。`MessageListPresentationContext` 只向 Footer 投影现有 `canLayoutVirtualList` 准入结果，不持有第二份状态；该值不能随 Virtuoso context 一起冻结。Footer 的 `useSyncExternalStore` 仅在准入时每秒订阅 Tab clock，并在不可呈现时撤销轮询、卸载 spinner 的动画节点（保留固定占位）；恢复时立即读取当前 clock。Chromium 可以延迟处理 `content-visibility:hidden` 后代的 class/style 变化，单纯移除动画 class 不保证立即清除已有 CSS animation。否则隐藏前的 loading snapshot 会使计时器在后台任务结束后仍永久运行。Tab clock 本身通过时间差累计，不依赖此轮询，也不因窗口隐藏、暂停采样或恢复而重置。
+
 - focus change 必须产生零个 Chat scroll command。
 - 可见失焦窗口的 `atBottomStateChange`、follow 与 pagination 正常工作。
 - suspension 期间消息/SSE 正常推进，但 data、firstItemIndex、height estimate 和行测量不进入 Virtuoso。

--- a/specs/tech_docs/tool_attachment_pipeline.md
+++ b/specs/tech_docs/tool_attachment_pipeline.md
@@ -123,6 +123,14 @@ Renderer 通过 `resolveTauriToolAttachmentUrl()` 把相对 `refPath` 映射为�
 
 特殊工具组件可以显示自己的文字 metadata，但不得再次渲染同一媒体或从结果文本正则恢复第二份附件。
 
+### 音频播放资源生命周期
+
+附件音频的播放 owner 是 Renderer `audioPlayer.ts` 单例；消息行只订阅状态，因此虚拟列表回收行不停止用户主动播放的音频。暂停保留 element、URL 和 position，结束、错误、`play()` 拒绝、显式停止则统一经过 `stopAudio()`：先摘除 listener，再 pause、移除 `src`、`load()` 重置媒体资源，最后撤销 blob URL 并清空状态。只清除 UI 的 path 或撤销 blob URL 不会卸载已加载的媒体元素。
+
+Settings TTS 试听由设置弹窗自身持有，`useTtsPreview` 只是其局部 lifecycle 实现，不复用附件单例。一次试听的 synthesis request、blob URL、media element 和 `play()` Promise 属于同一 operation。关闭、卸载或修改试听配置时立即使 operation 失效并释放媒体；旧请求完成、旧媒体事件、旧 `play()` Promise 均不得创建播放器、修改新试听状态或显示过期错误。现有 `apiPostJson` transport 不支持取消请求，因此在异步边界撤销后续播放资格；不增加通信模式，也不把后端合成完成等同于仍有播放许可。
+
+回归测试见 `audioPlayer.test.tsx` 与 `useTtsPreview.test.tsx`；覆盖终态资源释放、暂停/恢复保留位置、关闭期间异步返回、重新打开后的旧回调，以及 StrictMode setup/cleanup。
+
 ## 安全不变量
 
 ### 本地路径

--- a/specs/tech_docs/windows_platform.md
+++ b/specs/tech_docs/windows_platform.md
@@ -83,6 +83,16 @@ Task Activation Detector同样拥有 Job Object。timeout、stdout超限、Task 
 
 Launcher使用 no-follow检查、临时文件和原子 replace；路径 quoting必须覆盖空格、Unicode和 `%`。CLI mode attach parent console，并只使用当前 bundle的 Node和CLI。资源缺失时fail closed，不执行HOME旧 payload或系统 Node。
 
+## Windows 应用图标
+
+`lib.rs::app_context()` 在构建 App、窗口和托盘之前，将 Windows 的 `default_window_icon` 显式设为现有的 256×256 PNG（`icons/128x128@2x.png`）。运行时窗口和托盘继续从这一个默认图标派生；录音提示点按源图尺寸缩放。
+
+原因：当前 `tauri-codegen` 的 ICO 解码只读取 `entries()[0]`。仓库的 `icon.ico` 虽包含 16/24/32/48/64/128/256 七档，第一帧却是 16×16，直接用生成的默认 Context 会把这张小图交给 Windows，在任务栏和高 DPI 下放大失真。仅调整 `bundle.icon` 中 PNG 的顺序不能解决 Windows 优先读取 ICO 的行为。参见 [Tauri 上游问题 #14596](https://github.com/tauri-apps/tauri/issues/14596)。
+
+EXE、快捷方式与 NSIS 安装器继续使用完整的多尺寸 `icon.ico`，由 Windows Shell 选择尺寸；macOS 保留现有 ICNS 与独立托盘 template。不要为了运行时窗口重排或删减 ICO 的尺寸，也不要把托盘 template 用作应用图标。
+
+回归测试检查实际启动 Context 的图标分辨率与 RGBA 完整性。Windows 真机应检查 100/150/200% 缩放下的运行中任务栏、Alt+Tab、标题栏和托盘（含录音提示点）；区分运行时窗口图标与已固定快捷方式的 Shell 缓存。
+
 ## WebView2 与 CSP
 
 Windows production document origin、IPC和custom resource URL与macOS不同：

--- a/specs/tech_docs/windows_platform.md
+++ b/specs/tech_docs/windows_platform.md
@@ -95,6 +95,16 @@ Windows production document origin、IPC和custom resource URL与macOS不同：
 
 CSP authority是 `src-tauri/tauri.conf.json`。新增 network/subresource surface必须明确归入 control面或登记的数据面，不能为了通过WebView2直接扩大 `http:` / CDN通配。
 
+### 空闲 CPU / GPU / I/O 诊断
+
+持续负载必须追到仍在工作的生产者：JS timer/rAF、CSS 动画、媒体播放、native browser 页面或真实业务事件。页面复杂度会放大一次更新的成本，但不能单凭历史消息数量认定空闲持续渲染的原因；Chat 已有分页和虚拟列表。
+
+- 只采样 MyAgents 精确进程树，按 `--type` 区分 browser、renderer、GPU 和 utility；全机同名 `msedgewebview2.exe` 不都属于本应用。
+- `Win32_Perf*Data_PerfProc_Process` 的 I/O bytes 包含文件、网络和设备 I/O，不能换算成 SSD 写入量。目录净大小、缓存文件存在或单次修改时间也不能证明持续原地改写。需要用 ProcMon/ETW 的具体路径、操作和字节量确定磁盘写入；参见 [Microsoft 计数器定义](https://learn.microsoft.com/en-us/previous-versions/aa394323(v=vs.85))。
+- GPU 重启必须有进程退出/启动或失败事件；“存在 ShaderCache / GPUCache”不构成证据。性能定位优先采集 DevTools Performance 与 WebView2 ETW trace，见 [Microsoft WebView2 性能指南](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/performance)。
+- 对比前台会话、非会话 Tab、窗口隐藏/最小化、恢复和托盘彻底退出；记录桌宠、内嵌浏览器与媒体是否活跃。未经控制的低负载样本不能用作前台高占用问题的修复验收。
+- `--autoplay-policy=no-user-gesture-required` 只是播放权限，不会自行创建音频流。媒体 owner 仍须在结束/失败时卸载资源，并拒绝所属 UI 关闭后的异步播放，见 [音频资源生命周期](tool_attachment_pipeline.md#音频播放资源生命周期)。
+
 ## Native Browser child
 
 应用自有「浏览器」为每个 Product Session建立独立 BrowserContext和原生窗口/child WebView。Browser Host由Global Sidecar拥有，Chromium后代进入同一 process tree。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -230,6 +230,20 @@ fn should_request_exit_confirmation(code: Option<i32>, confirmed: bool) -> bool 
     code != Some(tauri::RESTART_EXIT_CODE) && !confirmed
 }
 
+fn app_context() -> tauri::Context<tauri::Wry> {
+    let context = tauri::generate_context!();
+    #[cfg(target_os = "windows")]
+    let context = {
+        let mut context = context;
+        // Tauri's ICO codegen decodes only entries()[0], which is 16x16 in our
+        // multi-resolution ICO. Supply the full-resolution runtime image before
+        // any windows or the tray are built; keep the ICO for EXE/installer use.
+        context.set_default_window_icon(Some(tauri::include_image!("icons/128x128@2x.png")));
+        context
+    };
+    context
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // ── DIAGNOSTIC PANIC HOOK (April 2026 crash investigation) ─────────────
@@ -1720,7 +1734,7 @@ pub fn run() {
                 _ => {}
             }
         })
-        .build(tauri::generate_context!())
+        .build(app_context())
         .expect("error while building tauri application");
 
     // Run with event handler to catch Cmd+Q, Dock quit, and Dock click
@@ -1885,6 +1899,24 @@ mod nav_guard_tests {
         classify_navigation(&Url::parse(s).expect("parse url"))
     }
 
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_runtime_icon_has_high_dpi_source() {
+        let context = super::app_context();
+        let icon = context.default_window_icon().expect("runtime app icon");
+        assert!(
+            icon.width() >= 256 && icon.height() >= 256,
+            "Windows must receive a high-resolution icon, got {}x{}",
+            icon.width(),
+            icon.height(),
+        );
+        assert_eq!(icon.width(), icon.height());
+        assert_eq!(
+            icon.rgba().len(),
+            (icon.width() * icon.height() * 4) as usize
+        );
+    }
+
     #[test]
     fn native_exit_requires_the_shared_frontend_confirmation_except_for_restart() {
         assert!(should_request_exit_confirmation(None, false));
@@ -2009,7 +2041,7 @@ mod nav_guard_tests {
         let source = include_str!("lib.rs");
         let window_handler = source
             .split_once(".on_window_event")
-            .and_then(|(_, tail)| tail.split_once(".build(tauri::generate_context!())"))
+            .and_then(|(_, tail)| tail.split_once(".build(app_context())"))
             .map(|(handler, _)| handler)
             .expect("window event handler source");
 

--- a/src/renderer/components/MessageList.footer.test.tsx
+++ b/src/renderer/components/MessageList.footer.test.tsx
@@ -71,6 +71,45 @@ function ClockOwner({
 describe('MessageList footer status positioning', () => {
   afterEach(() => vi.useRealTimers());
 
+  it.each(['tab', 'window'])('stops footer polling while the %s is hidden, even when the query ends there', (surface) => {
+    vi.useFakeTimers();
+    const startedAt = Date.now();
+    const elapsed = vi.fn(() => Math.floor((Date.now() - startedAt) / 1000));
+    const props = createBaseProps({ isLoading: true, getQueryElapsedSeconds: elapsed });
+    const { rerender } = render(<MessageList {...props} />);
+    act(() => vi.advanceTimersByTime(1000));
+    const hidden = surface === 'tab'
+      ? { isActive: false }
+      : { windowPresentation: { surfaceAvailable: false, generation: 1 } };
+    rerender(<MessageList {...props} {...hidden} />);
+    expect(document.querySelector('[data-chat-status-row] svg')).toBeNull();
+    elapsed.mockClear();
+    act(() => vi.advanceTimersByTime(5000));
+    expect(elapsed).not.toHaveBeenCalled();
+
+    rerender(<MessageList {...props} {...hidden} isLoading={false} />);
+    act(() => vi.advanceTimersByTime(5000));
+    expect(elapsed).not.toHaveBeenCalled();
+  });
+
+  it('resamples the Tab clock immediately when a running query becomes visible again', () => {
+    vi.useFakeTimers();
+    const startedAt = Date.now();
+    const props = createBaseProps({
+      isLoading: true,
+      getQueryElapsedSeconds: () => Math.floor((Date.now() - startedAt) / 1000),
+    });
+    const { rerender } = render(<MessageList {...props} />);
+    act(() => vi.advanceTimersByTime(1000));
+    const row = document.querySelector('[data-chat-status-row]');
+    rerender(<MessageList {...props} isActive={false} />);
+    act(() => vi.advanceTimersByTime(30000));
+    rerender(<MessageList {...props} />);
+    expect(document.querySelector('[data-chat-status-row]')).toBe(row);
+    expect(row).toHaveTextContent('31秒');
+    expect(row?.querySelector('svg')).toHaveClass('animate-spin');
+  });
+
   it('keeps query elapsed time and the status row across footer content/layout changes', () => {
     vi.useFakeTimers();
     const startedAt = Date.now();

--- a/src/renderer/components/MessageList.tsx
+++ b/src/renderer/components/MessageList.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, CheckCircle, Loader2, X } from 'lucide-react';
-import React, { memo, useCallback, useMemo, useState, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { createContext, memo, useCallback, useContext, useEffect, useMemo, useState, useSyncExternalStore, useLayoutEffect, useRef } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import type { ListItem, SizeFunction, VirtuosoHandle } from 'react-virtuoso';
 import type { TFunction } from 'i18next';
@@ -113,6 +113,10 @@ const DEFAULT_WINDOW_PRESENTATION: MainWindowPresentation = {
 const noopViewportAdmissionChanged = (_admitted: boolean, _presentationGeneration: number) => {};
 const noopItemsRendered = () => {};
 
+// Presentation admission remains owned by MessageList. Its projection must
+// reach the sampler even while Virtuoso's data/context are deliberately frozen.
+const MessageListPresentationContext = createContext(true);
+
 function isLargeRowShrink(reason: RowLayoutChangeReason): boolean {
   return reason === 'process-row-collapse' || reason === 'user-message-collapse-measured';
 }
@@ -145,11 +149,15 @@ function getRandomStreamingMessage(t: TFunction<'chat'>): string {
 
 const StatusTimer = memo(function StatusTimer({ message, getElapsedSeconds }: { message: string; getElapsedSeconds: () => number }) {
   const { t } = useTranslation('chat');
-  const [elapsedSeconds, setElapsedSeconds] = useState(() => getElapsedSeconds());
-  useEffect(() => {
-    const id = setInterval(() => setElapsedSeconds(getElapsedSeconds()), 1000);
+  const canPresent = useContext(MessageListPresentationContext);
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    if (!canPresent) return () => {};
+    const id = setInterval(onStoreChange, 1000);
     return () => clearInterval(id);
-  }, [getElapsedSeconds]);
+  }, [canPresent]);
+  // The Tab clock keeps advancing without a timer. Re-subscription samples its
+  // current value on restore; hidden snapshots never keep a polling loop alive.
+  const elapsedSeconds = useSyncExternalStore(subscribe, getElapsedSeconds);
   const elapsedText = elapsedSeconds > 0 ? formatElapsedTime(elapsedSeconds, t) : null;
   const displayText = elapsedText ? `${message} (${elapsedText})` : message;
   return (
@@ -159,7 +167,12 @@ const StatusTimer = memo(function StatusTimer({ message, getElapsedSeconds }: { 
       style={{ height: STATUS_ROW_HEIGHT_PX }}
       title={displayText}
     >
-      <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+      {/* Retire the animated node, preserving its slot. Chromium can defer a
+          class/style removal inside content-visibility:hidden, retaining the
+          old CSS animation until the subtree becomes renderable again. */}
+      <span className="h-3 w-3 shrink-0" aria-hidden="true">
+        {canPresent && <Loader2 className="h-full w-full animate-spin" />}
+      </span>
       <span className="min-w-0 truncate">{displayText}</span>
     </div>
   );
@@ -693,6 +706,7 @@ const MessageList = memo(function MessageList({
   }, [debugProbe, onItemsRendered]);
 
   return (
+    <MessageListPresentationContext.Provider value={canLayoutVirtualList}>
     <div
       ref={viewportRootRef}
       className="relative flex-1"
@@ -755,6 +769,7 @@ const MessageList = memo(function MessageList({
         itemContent={renderItem}
       />
     </div>
+    </MessageListPresentationContext.Provider>
   );
 });
 

--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -38,6 +38,7 @@ import { homeDir, join } from '@tauri-apps/api/path';
 
 import { track } from '@/analytics';
 import { useCloseLayer } from '@/hooks/useCloseLayer';
+import { useTtsPreview, type TtsPreviewSettings } from './hooks/useTtsPreview';
 import OverlayBackdrop from '@/components/OverlayBackdrop';
 import { apiFetch, apiGetJson, apiPostJson } from '@/api/apiFetch';
 import { useToast } from '@/components/Toast';
@@ -1365,19 +1366,16 @@ export default function Settings({
     'w-full h-1.5 rounded-full appearance-none cursor-pointer bg-[var(--line)] [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--accent)] [&::-webkit-slider-thumb]:shadow-md [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:transition-transform [&::-webkit-slider-thumb]:hover:scale-110';
 
   // Edge TTS MCP custom settings dialog
-  const [edgeTtsSettings, setEdgeTtsSettings] = useState<{
-    defaultVoice: string;
-    defaultRate: number;
-    defaultVolume: number;
-    defaultPitch: number;
-    defaultOutputFormat: string;
-  } | null>(null);
+  const [edgeTtsSettings, setEdgeTtsSettings] = useState<TtsPreviewSettings | null>(null);
   const [ttsPreviewText, setTtsPreviewText] = useState(
     '你好，这是一段语音合成测试。Hello, this is a text-to-speech test.',
   );
-  const [ttsPreviewLoading, setTtsPreviewLoading] = useState(false);
-  const [ttsPreviewPlaying, setTtsPreviewPlaying] = useState(false);
-  const ttsAudioRef = useRef<HTMLAudioElement | null>(null);
+  const {
+    loading: ttsPreviewLoading,
+    playing: ttsPreviewPlaying,
+    toggle: toggleTtsPreview,
+    stop: stopTtsPreview,
+  } = useTtsPreview(edgeTtsSettings);
 
   // OAuth polling cleanup refs (P0-7: prevent interval leak on unmount)
   const oauthPollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
@@ -2081,94 +2079,7 @@ export default function Settings({
     }
   };
 
-  const stopTtsPreview = useCallback(() => {
-    if (ttsAudioRef.current) {
-      const src = ttsAudioRef.current.src;
-      ttsAudioRef.current.pause();
-      ttsAudioRef.current.onended = null;
-      ttsAudioRef.current.onerror = null;
-      ttsAudioRef.current = null;
-      if (src.startsWith('blob:')) URL.revokeObjectURL(src);
-    }
-    setTtsPreviewPlaying(false);
-  }, []);
-
-  // Stop audio when dialog closes or component unmounts
-  useEffect(() => {
-    if (!edgeTtsSettings) stopTtsPreview();
-    return () => {
-      stopTtsPreview();
-    };
-  }, [edgeTtsSettings, stopTtsPreview]);
-
-  const handlePreviewTts = async () => {
-    if (!edgeTtsSettings) return;
-
-    // If currently playing, stop
-    if (ttsPreviewPlaying) {
-      stopTtsPreview();
-      return;
-    }
-
-    setTtsPreviewLoading(true);
-    try {
-      const result = await apiPostJson<{
-        success: boolean;
-        audioBase64?: string;
-        mimeType?: string;
-        error?: string;
-      }>('/api/edge-tts/preview', {
-        text: ttsPreviewText,
-        voice: edgeTtsSettings.defaultVoice,
-        rate: fmtTtsRate(edgeTtsSettings.defaultRate),
-        volume: fmtTtsRate(edgeTtsSettings.defaultVolume),
-        pitch: fmtTtsPitch(edgeTtsSettings.defaultPitch),
-        outputFormat: edgeTtsSettings.defaultOutputFormat,
-      });
-      if (result.success && result.audioBase64) {
-        // Decode base64 → Blob URL (data URIs don't work for audio in WKWebView)
-        const bin = atob(result.audioBase64);
-        const bytes = new Uint8Array(bin.length);
-        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-        const blob = new Blob([bytes], {
-          type: result.mimeType || 'audio/mpeg',
-        });
-        const blobUrl = URL.createObjectURL(blob);
-
-        const audio = new Audio(blobUrl);
-        ttsAudioRef.current = audio;
-        audio.onended = () => {
-          URL.revokeObjectURL(blobUrl);
-          setTtsPreviewPlaying(false);
-          ttsAudioRef.current = null;
-        };
-        audio.onerror = () => {
-          URL.revokeObjectURL(blobUrl);
-          toast.error(tSettings('toolbox.toasts.audioPlayFailed'));
-          setTtsPreviewPlaying(false);
-          ttsAudioRef.current = null;
-        };
-        await audio.play();
-        setTtsPreviewPlaying(true);
-      } else {
-        toast.error(
-          result.error || tSettings('toolbox.toasts.ttsPreviewFailed'),
-        );
-      }
-    } catch {
-      // Clean up blob URL on play() rejection to avoid memory leak
-      if (ttsAudioRef.current) {
-        const src = ttsAudioRef.current.src;
-        ttsAudioRef.current.onended = null;
-        ttsAudioRef.current.onerror = null;
-        ttsAudioRef.current = null;
-        if (src.startsWith('blob:')) URL.revokeObjectURL(src);
-      }
-      toast.error(tSettings('toolbox.toasts.ttsPreviewRequestFailed'));
-    } finally {
-      setTtsPreviewLoading(false);
-    }
-  };
+  const handlePreviewTts = () => toggleTtsPreview(ttsPreviewText);
 
   // OAuth: probe MCP server for OAuth requirements (returns probe result for chaining)
   const handleMcpOAuthProbe = async (

--- a/src/renderer/pages/settings/hooks/useTtsPreview.test.tsx
+++ b/src/renderer/pages/settings/hooks/useTtsPreview.test.tsx
@@ -1,0 +1,172 @@
+import { StrictMode } from 'react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTtsPreview, type TtsPreviewSettings } from './useTtsPreview';
+
+const { apiPostJson, toast } = vi.hoisted(() => ({
+  apiPostJson: vi.fn(),
+  toast: { error: vi.fn() },
+}));
+vi.mock('@/api/apiFetch', () => ({ apiPostJson }));
+vi.mock('@/components/Toast', () => ({ useToast: () => toast }));
+
+const settings: TtsPreviewSettings = {
+  defaultVoice: 'zh-CN-XiaoxiaoNeural', defaultRate: 0, defaultVolume: -10,
+  defaultPitch: 2, defaultOutputFormat: 'audio-24khz-48kbitrate-mono-mp3',
+};
+const audioResult = { success: true, audioBase64: 'AA==', mimeType: 'audio/mpeg' };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((done, fail) => { resolve = done; reject = fail; });
+  return { promise, resolve, reject };
+}
+
+function mountPreview() {
+  return renderHook(({ value }: { value: TtsPreviewSettings | null }) => useTtsPreview(value), {
+    initialProps: { value: settings as TtsPreviewSettings | null },
+    wrapper: StrictMode,
+  });
+}
+
+describe('settings TTS preview lifecycle', () => {
+  let elements: HTMLAudioElement[];
+
+  beforeEach(() => {
+    elements = [];
+    apiPostJson.mockReset().mockResolvedValue(audioResult);
+    toast.error.mockReset();
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+    vi.stubGlobal('Audio', function Audio(src: string) {
+      const audio = document.createElement('audio');
+      audio.src = src;
+      elements.push(audio);
+      return audio;
+    });
+    let nextUrl = 0;
+    vi.stubGlobal('URL', class extends URL {
+      static createObjectURL = vi.fn(() => `blob:preview-${++nextUrl}`);
+      static revokeObjectURL = vi.fn();
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(['close', 'unmount', 'configure'])(
+    'cannot create a player when synthesis finishes after %s', async (action) => {
+      const pending = deferred<typeof audioResult>();
+      apiPostJson.mockReturnValueOnce(pending.promise);
+      const hook = mountPreview();
+      let playing!: Promise<void>;
+      act(() => { playing = hook.result.current.toggle('preview'); });
+      expect(hook.result.current.loading).toBe(true);
+      if (action === 'unmount') hook.unmount();
+      else hook.rerender({ value: action === 'close' ? null : { ...settings, defaultRate: 10 } });
+      await act(async () => { pending.resolve(audioResult); await playing; });
+      expect(elements).toHaveLength(0);
+      expect(URL.createObjectURL).not.toHaveBeenCalled();
+      expect(toast.error).not.toHaveBeenCalled();
+      if (action !== 'unmount') expect(hook.result.current.loading).toBe(false);
+    },
+  );
+
+  it.each(['resolve', 'reject'])(
+    'ignores an old synthesis %s after reopening and playing a new preview', async (settlement) => {
+      const pending = deferred<typeof audioResult>();
+      apiPostJson.mockReturnValueOnce(pending.promise);
+      const hook = mountPreview();
+      let first!: Promise<void>;
+      act(() => { first = hook.result.current.toggle('first'); });
+      hook.rerender({ value: null });
+      hook.rerender({ value: settings });
+      await act(async () => { await hook.result.current.toggle('second'); });
+      await act(async () => {
+        if (settlement === 'resolve') pending.resolve(audioResult);
+        else pending.reject(new Error('stale synthesis'));
+        await first;
+      });
+      expect(elements).toHaveLength(1);
+      expect(elements[0].src).toBe('blob:preview-1');
+      expect(hook.result.current.playing).toBe(true);
+      expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+      expect(toast.error).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['ended', 'error', 'stop', 'close', 'unmount'])(
+    'unloads the media resource and listeners on %s', async (action) => {
+      const hook = mountPreview();
+      await act(async () => { await hook.result.current.toggle('preview'); });
+      expect(hook.result.current.playing).toBe(true);
+      const audio = elements[0];
+      await act(async () => {
+        if (action === 'stop') await hook.result.current.toggle('preview');
+        else if (action === 'close') hook.rerender({ value: null });
+        else if (action === 'unmount') hook.unmount();
+        else audio.dispatchEvent(new Event(action));
+      });
+      expect(audio.hasAttribute('src')).toBe(false);
+      expect(audio.pause).toHaveBeenCalledOnce();
+      expect(audio.load).toHaveBeenCalledOnce();
+      expect(audio.onended).toBeNull();
+      expect(audio.onerror).toBeNull();
+      expect(URL.revokeObjectURL).toHaveBeenCalledExactlyOnceWith('blob:preview-1');
+      if (action !== 'unmount') expect(hook.result.current.playing).toBe(false);
+    },
+  );
+
+  it('releases the element and URL on play rejection without a media error event', async () => {
+    vi.mocked(HTMLMediaElement.prototype.play).mockRejectedValueOnce(new Error('play rejected'));
+    const hook = mountPreview();
+    await act(async () => { await hook.result.current.toggle('preview'); });
+    expect(elements[0].hasAttribute('src')).toBe(false);
+    expect(elements[0].load).toHaveBeenCalledOnce();
+    expect(URL.revokeObjectURL).toHaveBeenCalledExactlyOnceWith('blob:preview-1');
+    expect(hook.result.current).toMatchObject({ playing: false, loading: false });
+    expect(toast.error).toHaveBeenCalledOnce();
+  });
+
+  it.each(['resolve', 'reject'])(
+    'ignores a retired play promise %s and its late events', async (settlement) => {
+      const pending = deferred<void>();
+      vi.mocked(HTMLMediaElement.prototype.play).mockReturnValueOnce(pending.promise);
+      const hook = mountPreview();
+      let first!: Promise<void>;
+      await act(async () => { first = hook.result.current.toggle('first'); });
+      const retired = elements[0];
+      const lateEnd = retired.onended;
+      const lateError = retired.onerror;
+      hook.rerender({ value: null });
+      hook.rerender({ value: settings });
+      await act(async () => { await hook.result.current.toggle('second'); });
+      await act(async () => {
+        lateEnd?.call(retired, new Event('ended'));
+        lateError?.call(retired, new Event('error'));
+        if (settlement === 'resolve') pending.resolve();
+        else pending.reject(new Error('retired playback'));
+        await first;
+      });
+      expect(elements[1].src).toBe('blob:preview-2');
+      expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:preview-2');
+      expect(hook.result.current.playing).toBe(true);
+      expect(toast.error).not.toHaveBeenCalled();
+    },
+  );
+
+  it('forwards the chosen preview settings through the existing API', async () => {
+    const hook = mountPreview();
+    await act(async () => { await hook.result.current.toggle('preview'); });
+    expect(apiPostJson).toHaveBeenCalledExactlyOnceWith('/api/edge-tts/preview', {
+      text: 'preview', voice: settings.defaultVoice, rate: '+0%', volume: '-10%',
+      pitch: '+2Hz', outputFormat: settings.defaultOutputFormat,
+    });
+  });
+});

--- a/src/renderer/pages/settings/hooks/useTtsPreview.ts
+++ b/src/renderer/pages/settings/hooks/useTtsPreview.ts
@@ -1,0 +1,130 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { apiPostJson } from '@/api/apiFetch';
+import { useToast } from '@/components/Toast';
+
+export interface TtsPreviewSettings {
+  defaultVoice: string;
+  defaultRate: number;
+  defaultVolume: number;
+  defaultPitch: number;
+  defaultOutputFormat: string;
+}
+
+interface PreviewOperation {
+  audio: HTMLAudioElement | null;
+  blobUrl: string | null;
+}
+
+type PreviewStatus = 'idle' | 'loading' | 'playing';
+
+/** The settings dialog owns both synthesis admission and the resulting player. */
+export function useTtsPreview(settings: TtsPreviewSettings | null) {
+  const { t } = useTranslation('settings');
+  const toast = useToast();
+  const [preview, setPreview] = useState<{ settings: TtsPreviewSettings | null; status: PreviewStatus }>({
+    settings, status: 'idle',
+  });
+  // Reset the dialog's own projection when its input changes, before children
+  // paint. The layout effect below only retires external resources.
+  if (preview.settings !== settings) setPreview({ settings, status: 'idle' });
+  const setStatus = useCallback((status: PreviewStatus) => {
+    setPreview({ settings, status });
+  }, [settings]);
+  const operationRef = useRef<PreviewOperation | null>(null);
+  const mountedRef = useRef(false);
+
+  const retire = useCallback(() => {
+    // Invalidate before teardown: queued media events and late async responses
+    // belong to this exact operation and cannot touch a replacement preview.
+    const operation = operationRef.current;
+    operationRef.current = null;
+    if (operation?.audio) {
+      operation.audio.onended = null;
+      operation.audio.onerror = null;
+      operation.audio.pause();
+      operation.audio.removeAttribute('src');
+      operation.audio.load();
+    }
+    if (operation?.blobUrl) URL.revokeObjectURL(operation.blobUrl);
+  }, []);
+
+  const stop = useCallback(() => {
+    retire();
+    if (mountedRef.current) setStatus('idle');
+  }, [retire, setStatus]);
+
+  // Retire on the close/configuration commit, before a pending synthesis or
+  // play() completion can regain permission to play. Setup also works after
+  // React's setup → cleanup → setup probe.
+  useLayoutEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      retire();
+    };
+  }, [settings, retire]);
+
+  const toggle = useCallback(async (text: string) => {
+    if (!settings || !mountedRef.current) return;
+    if (operationRef.current) {
+      stop();
+      return;
+    }
+
+    const operation: PreviewOperation = { audio: null, blobUrl: null };
+    operationRef.current = operation;
+    const isCurrent = () => operationRef.current === operation;
+    setStatus('loading');
+
+    try {
+      const percent = (value: number) => `${value >= 0 ? '+' : ''}${value}%`;
+      const result = await apiPostJson<{
+        success: boolean;
+        audioBase64?: string;
+        mimeType?: string;
+        error?: string;
+      }>('/api/edge-tts/preview', {
+        text,
+        voice: settings.defaultVoice,
+        rate: percent(settings.defaultRate),
+        volume: percent(settings.defaultVolume),
+        pitch: `${settings.defaultPitch >= 0 ? '+' : ''}${settings.defaultPitch}Hz`,
+        outputFormat: settings.defaultOutputFormat,
+      });
+      // apiPostJson's Tauri transport has no request cancellation API. The
+      // dialog still revokes playback admission immediately, before decoding
+      // bytes or creating any WebView media resource from a stale response.
+      if (!isCurrent()) return;
+      if (!result.success || !result.audioBase64) {
+        stop();
+        toast.error(result.error || t('toolbox.toasts.ttsPreviewFailed'));
+        return;
+      }
+
+      const binary = atob(result.audioBase64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      operation.blobUrl = URL.createObjectURL(new Blob([bytes], {
+        type: result.mimeType || 'audio/mpeg',
+      }));
+      const audio = new Audio(operation.blobUrl);
+      operation.audio = audio;
+      audio.onended = () => { if (isCurrent()) stop(); };
+      audio.onerror = () => {
+        if (!isCurrent()) return;
+        stop();
+        toast.error(t('toolbox.toasts.audioPlayFailed'));
+      };
+      await audio.play();
+      if (isCurrent()) setStatus('playing');
+    } catch {
+      if (!isCurrent()) return;
+      stop();
+      toast.error(t('toolbox.toasts.ttsPreviewRequestFailed'));
+    }
+  }, [settings, setStatus, stop, t, toast]);
+
+  return { loading: preview.status === 'loading', playing: preview.status === 'playing', toggle, stop };
+}

--- a/src/renderer/utils/audioPlayer.test.tsx
+++ b/src/renderer/utils/audioPlayer.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { playAudio, seekTo, stopAudio, subscribeAudio, toggleAudio } from './audioPlayer';
+
+vi.mock('@/utils/browserMock', () => ({ isTauriEnvironment: () => true }));
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+
+describe('audio player resource lifecycle', () => {
+  let elements: HTMLAudioElement[];
+  let revoke: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    elements = [];
+    invoke.mockReset().mockResolvedValue('AA==');
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+    vi.stubGlobal('Audio', function Audio(src: string) {
+      const element = document.createElement('audio');
+      element.src = src;
+      elements.push(element);
+      return element;
+    });
+    let nextUrl = 0;
+    vi.stubGlobal('URL', class extends URL {
+      static createObjectURL = vi.fn(() => `blob:audio-${++nextUrl}`);
+      static revokeObjectURL = vi.fn();
+    });
+    revoke = vi.mocked(URL.revokeObjectURL);
+  });
+
+  afterEach(() => {
+    stopAudio();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(['ended', 'error'])('releases the media element on %s and ignores retired events', async (event) => {
+    await playAudio('/first.wav');
+    const retired = elements[0];
+    retired.dispatchEvent(new Event(event));
+
+    expect(retired.hasAttribute('src')).toBe(false);
+    expect(retired.load).toHaveBeenCalledOnce();
+    expect(revoke).toHaveBeenCalledWith('blob:audio-1');
+
+    await playAudio('/second.wav');
+    const listener = vi.fn();
+    const unsubscribe = subscribeAudio(listener);
+    retired.dispatchEvent(new Event('ended'));
+    retired.dispatchEvent(new Event('error'));
+    retired.dispatchEvent(new Event('timeupdate'));
+    expect(listener).not.toHaveBeenCalled();
+    expect(revoke).not.toHaveBeenCalledWith('blob:audio-2');
+    unsubscribe();
+  });
+
+  it('releases the element when play rejects without a media error event', async () => {
+    vi.mocked(HTMLMediaElement.prototype.play).mockRejectedValueOnce(new Error('decode failed'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    await playAudio('/broken.wav');
+    expect(elements[0].hasAttribute('src')).toBe(false);
+    expect(elements[0].load).toHaveBeenCalledOnce();
+    expect(revoke).toHaveBeenCalledWith('blob:audio-1');
+  });
+
+  it('preserves the loaded element and seek position for pause/resume', async () => {
+    await playAudio('/first.wav');
+    const element = elements[0];
+    Object.defineProperty(element, 'paused', { configurable: true, value: false });
+    Object.defineProperty(element, 'duration', { value: 60 });
+    seekTo(12);
+    toggleAudio('/first.wav');
+    expect(element.pause).toHaveBeenCalledOnce();
+    expect(element.src).toBe('blob:audio-1');
+    expect(element.currentTime).toBe(12);
+    expect(revoke).not.toHaveBeenCalled();
+
+    Object.defineProperty(element, 'paused', { value: true });
+    toggleAudio('/first.wav');
+    expect(element.play).toHaveBeenCalledTimes(2);
+    expect(elements).toHaveLength(1);
+    expect(element.currentTime).toBe(12);
+  });
+
+  it('does not start playback when a stopped file read completes late', async () => {
+    let resolve!: (value: string) => void;
+    invoke.mockImplementationOnce(() => new Promise<string>(done => { resolve = done; }));
+    const playing = playAudio('/first.wav');
+    // resolveAudioUrl dynamically imports the Tauri command module.
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledOnce());
+    stopAudio();
+    resolve('AA==');
+    await playing;
+    expect(elements).toHaveLength(0);
+    expect(revoke).toHaveBeenCalledWith('blob:audio-1');
+  });
+
+  it('does not let a retired play rejection stop a replacement player', async () => {
+    let reject!: (error: Error) => void;
+    vi.mocked(HTMLMediaElement.prototype.play).mockImplementationOnce(() => new Promise((_resolve, fail) => { reject = fail; }));
+    const first = playAudio('/first.wav');
+    await vi.waitFor(() => expect(elements).toHaveLength(1));
+    await playAudio('/second.wav');
+    reject(new Error('retired'));
+    await first;
+    expect(elements[1].src).toBe('blob:audio-2');
+    expect(revoke).not.toHaveBeenCalledWith('blob:audio-2');
+  });
+});

--- a/src/renderer/utils/audioPlayer.ts
+++ b/src/renderer/utils/audioPlayer.ts
@@ -107,8 +107,11 @@ function detachListeners(el: HTMLAudioElement) {
   el.removeEventListener('error', onError);
 }
 
-function onEnded() { currentPath = null; revokeBlobUrl(); notify(); }
-function onError() { currentPath = null; revokeBlobUrl(); notify(); }
+// Revoking a blob URL only prevents future URL resolution; it does not unload
+// an element that already holds the media resource. Every terminal path must
+// retire the element and its listeners through the same owner as explicit stop.
+function onEnded() { stopAudio(); }
+function onError() { stopAudio(); }
 
 function revokeBlobUrl() {
   if (currentBlobUrl) {
@@ -149,9 +152,7 @@ export async function playAudio(filePath: string): Promise<void> {
     // Only reset if this is still the active generation
     if (gen === playGeneration) {
       console.error('[audioPlayer] playback failed:', err);
-      currentPath = null;
-      revokeBlobUrl();
-      notify();
+      stopAudio();
     }
   }
 }


### PR DESCRIPTION
## Description

汇总 Windows 构建、媒体生命周期和任务栏图标的三项修复：

- Sherpa 构建使用 `CMAKE_CXX_FLAGS_INIT`，保留 MSVC 默认的 `/EHsc`，并只对 MSVC 保护 hclust 不支持的 `FENV_ACCESS` pragma，消除 C4530/C4068 的根因。
- 音频结束、失败时完整释放媒体资源；关闭或修改 TTS 试听设置后，旧异步请求不能再次启动播放。隐藏聊天列表时停止 Footer 轮询并卸载动画节点，恢复时直接读取现有 Tab 时钟。
- Windows 默认窗口图标显式使用现有 256×256 PNG，避免 Tauri 只读取 ICO 第一帧的 16×16 小图并将其放大；EXE 和安装器保留完整的多尺寸 ICO。

包含 `f0ff490f`、`635a9f6d`、`787bd0c7`。`bugfix/windows-setup-native-inference` 已在 `main`；其余两个本地 `bugfix` 分支的全部提交均已包含在本 PR，无合并冲突。

## Validation

- `npm run typecheck`：通过。
- `npm run lint`：通过；依赖检查有 12 条既有 orphan 警告，0 errors。
- `node --test scripts/sherpa-source-extraction.test.mjs scripts/build-resource-staging.test.mjs scripts/speech-inference-resource-cache.test.mjs`：在干净 worktree 中 22 项通过。
- 前端回归：音频和 TTS 试听 20 项、Footer 和列表冻结 27 项通过；隐藏状态下的浏览器采样确认计时轮询和 spinner 动画停止。
- Windows Rust 编译通过，图标/启动/托盘 10 项测试通过。直接执行 Cargo 生成的测试程序因缺少 Windows manifest 报 `0xc0000139`；在临时测试副本中嵌入 Tauri 默认 manifest 后完成验证，未改动发布配置。
- 本机 150% 缩放下确认旧版窗口图标仅 16×16；新启动 Context 的回归测试验证图标至少为 256×256。尚未重新打包安装并进行多 DPI 视觉验收。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have run `npm run typecheck` and `npm run lint`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] I created these changes or have the right to submit them under the project's community and commercial licensing paths
- [x] I documented the source and license of any third-party code, prompts, assets, generated material, or dependencies added by this PR
- [x] I understand that a Contributor License Agreement may be required before merge

未新增第三方依赖、图标素材或许可证变更；复用现有已锁定的源代码与资产。

## Related Issues

Related to #567。这里只修复已证实的媒体资源释放、试听生命周期和隐藏 Footer 活动问题；原反馈的持续高 CPU/GPU/I/O 现象尚未完全定位，不自动关闭该 issue。
